### PR TITLE
Add nonblocking RNG trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-
+- A nonblocking trait for interfacing with random number generation hardware.
 
 ### Changed
 - The current versions of `InputPin` have been proven. These are `digital::v1::InputPin` 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,6 +689,7 @@ pub mod blocking;
 pub mod digital;
 pub mod fmt;
 pub mod prelude;
+pub mod rng;
 pub mod serial;
 pub mod spi;
 pub mod timer;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,6 +25,8 @@ pub use digital::OutputPin as _embedded_hal_digital_OutputPin;
 #[cfg(feature = "unproven")]
 #[allow(deprecated)]
 pub use digital::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
+#[cfg(feature = "unproven")]
+pub use rng::Read as _embedded_hal_rng_Read;
 pub use serial::Read as _embedded_hal_serial_Read;
 pub use serial::Write as _embedded_hal_serial_Write;
 pub use spi::FullDuplex as _embedded_hal_spi_FullDuplex;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,17 @@
+//! Random Number Generator Interface
+
+#[cfg(feature = "unproven")]
+use nb;
+
+/// Nonblocking stream of random bytes.
+#[cfg(feature = "unproven")]
+// reason: No implementation or users yet
+pub trait Read {
+    /// An enumeration of RNG errors.
+    ///
+    /// For infallible implementations, will be `Infallible`
+    type Error;
+
+    /// Get a number of bytes from the RNG.
+    fn read(&mut self, buf: &mut [u8]) -> nb::Result<usize, Self::Error>;
+}


### PR DESCRIPTION
As discussed in #45, this is a nonblocking variant of an RNG interface.