### PR TITLE
4th `digital::IoPin` proposal from #29

### DIFF
--- a/src/digital.rs
+++ b/src/digital.rs
@@ -24,3 +24,11 @@ pub trait InputPin {
     /// Is the input pin low?
     fn is_low(&self) -> bool;
 }
+
+pub trait IoPin {
+    type Input: InputPin + IoPin<Input = Self::Input, Output = Self::Output>;
+    type Output: OutputPin + IoPin<Input = Self::Input, Output = Self::Output>;
+
+    fn into_input(self) -> Self::Input;
+    fn into_output(self) -> Self::Output;
+}

--- a/src/digital.rs
+++ b/src/digital.rs
@@ -25,10 +25,26 @@ pub trait InputPin {
     fn is_low(&self) -> bool;
 }
 
+/// Pins that can switch between input and output modes at runtime
+#[cfg(feature = "unproven")]
 pub trait IoPin {
+    /// Used by [`into_input()`](#tymethod.into_input)
+    ///
+    /// In addition to being an [`InputPin`](trait.InputPin.html), the
+    /// target type must implement `IoPin` so that the mode can be
+    /// changed again.
     type Input: InputPin + IoPin<Input = Self::Input, Output = Self::Output>;
+
+    /// Used by [`into_output()`](#tymethod.into_output)
+    ///
+    /// In addition to being an [`OutputPin`](trait.OutputPin.html),
+    /// the target type must implement `IoPin` so that the mode can be
+    /// changed again.
     type Output: OutputPin + IoPin<Input = Self::Input, Output = Self::Output>;
 
+    /// Configure as [`InputPin`](trait.InputPin.html)
     fn into_input(self) -> Self::Input;
+
+    /// Configure as [`OutputPin`](trait.OutputPin.html)
     fn into_output(self) -> Self::Output;
 }


### PR DESCRIPTION
This is Jorge Aparicio's most recent `IoPin` proposal from #29. It leverages the type system for representing the output state. It does not automatically (unintentionally) switch modes. It avoids closures.

I've implemented it [in a proof of concept](https://github.com/astro/dht22-rs/commit/51eef5c18a37133faaf6a0481cf0597b61e4d828#diff-639fbc4ef05b315af92b4d836c31b023). The only issue regarding ergonomics is the additional `IoPin` implementation that is required for both `InputPin` and `OutputPin`:
```rust
/// For an OutputPin
impl<'a> IoPin for MyOutput<'a> {
    type Input = MyInput<'a>;
    type Output = Self;

    fn into_input(self) -> Self::Input {
        MyPin {
            gpio: self.gpio
        }.into_input()
    }

    fn into_output(self) -> Self::Output {
        self
    }
}
```