### PR TITLE
Remove InputPin unproven flag per #41

### DIFF
--- a/src/digital.rs
+++ b/src/digital.rs
@@ -109,9 +109,6 @@ pub mod toggleable {
 }
 
 /// Single digital input pin
-///
-/// *This trait is available if embedded-hal is built with the `"unproven"` feature.*
-#[cfg(feature = "unproven")]
 pub trait InputPin {
     /// Is the input pin high?
     fn is_high(&self) -> bool;


### PR DESCRIPTION
`InputPin` trait has been demonstrated (see: https://github.com/rust-embedded/embedded-hal/issues/41#issuecomment-368315610 amongst other impls), this PR removes the `unproven` feature flag. This is either blocked by or dependent on #95 and #97 (what do you think, @eldruin?), and blocks https://github.com/rust-embedded/linux-embedded-hal/pull/11