### PR TITLE
Add constants for various 'SPI mode numbers'

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -52,3 +52,27 @@ pub struct Mode {
     /// Clock phase
     pub phase: Phase,
 }
+
+/// Helper for CPOL = 0, CPHA = 0
+pub const MODE_0: Mode = Mode {
+    polarity: Polarity::IdleLow,
+    phase: Phase::CaptureOnFirstTransition,
+};
+
+/// Helper for CPOL = 0, CPHA = 1
+pub const MODE_1: Mode = Mode {
+    polarity: Polarity::IdleLow,
+    phase: Phase::CaptureOnSecondTransition,
+};
+
+/// Helper for CPOL = 1, CPHA = 0
+pub const MODE_2: Mode = Mode {
+    polarity: Polarity::IdleHigh,
+    phase: Phase::CaptureOnFirstTransition,
+};
+
+/// Helper for CPOL = 1, CPHA = 1
+pub const MODE_3: Mode = Mode {
+    polarity: Polarity::IdleHigh,
+    phase: Phase::CaptureOnSecondTransition,
+};


### PR DESCRIPTION
I found myself being pretty confused by the terminology within the HAL for SPI configuration as it seems the terms are ST-specific. Through some Googling I figured out what the modes *should* be, but I'm a hobbyist and would welcome a second opinion.

Hopefully these static constants help others figure it out faster.

Feedback welcome!