### PR TITLE
Add example of opaque CountDown type usage

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -63,7 +63,6 @@ use void::Void;
 /// (concrete) `CountDown::Time` type:
 /// ```rust
 /// extern crate embedded_hal as hal;
-/// #[macro_use(block)]
 ///
 /// pub fn uses_timer<T, U>(t: T)
 /// where

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -64,7 +64,7 @@ use void::Void;
 /// ```rust
 /// extern crate embedded_hal as hal;
 ///
-/// pub fn uses_timer<T, U>(t: T)
+/// pub fn uses_timer<T, U>(t: &mut T)
 /// where
 ///     T: hal::timer::CountDown<Time=U>,
 ///     U: From<u32>,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -57,6 +57,23 @@ use void::Void;
 /// #     fn wait(&mut self) -> ::nb::Result<(), Void> { Ok(()) }
 /// # }
 /// ```
+///
+/// If you want to use a CountDown timer as an opaque type in a HAL-based driver, you have to add
+/// some type bounds to make sure arguments passed to `start` can be used by the underlying
+/// (concrete) `CountDown::Time` type:
+/// ```rust
+/// extern crate embedded_hal as hal;
+/// #[macro_use(block)]
+///
+/// pub fn uses_timer<T, U>(t: T)
+/// where
+///     T: hal::timer::CountDown<Time=U>,
+///     U: From<u32>,
+/// {
+///     // delay an arbitrary 1 time unit
+///     t.start(1);
+/// }
+/// ```
 pub trait CountDown {
     /// The unit of time used by this timer
     type Time;


### PR DESCRIPTION
This PR adds a small doc update to illustrate how to permit using the `start` function of the CountDown trait when writing a driver.