### PR TITLE
impl Write for serial::Write

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,0 +1,17 @@
+//! Implementation of `core::fmt::Write` for the HAL's `serial::Write`.
+//!
+//! TODO write example of usage
+use core::fmt::{Result, Write};
+
+impl<Word, Error> Write for ::serial::Write<Word, Error=Error>
+where
+    Word: From<u8>,
+{
+    fn write_str(&mut self, s: &str) -> Result {
+        let _ = s.as_bytes()
+            .into_iter()
+            .map(|c| block!(self.write(Word::from(*c))))
+            .last();
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -692,6 +692,7 @@ extern crate void;
 pub mod adc;
 pub mod blocking;
 pub mod digital;
+pub mod fmt;
 pub mod prelude;
 pub mod serial;
 pub mod spi;


### PR DESCRIPTION
Shamelessly pilfered from [@therealprof's code](https://github.com/therealprof/stm32f042-hal/blob/master/src/serial.rs). Still needs Changelog entry, but I thought this was a good idea after a discussion on IRC.