### PR TITLE
Document implicit assumption in non-blocking spi trait

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -8,12 +8,12 @@ use nb;
 ///
 /// - It's the task of the user of this interface to manage the slave select lines
 ///
-/// - Due to how full duplex SPI works each `read` call must be preceded by a `send` call.
+/// - Due to how full duplex SPI works each `try_read` call must be preceded by a `try_send` call.
 ///
-/// - `read` calls only return the data received with the last `send` call.
+/// - `try_read` calls only return the data received with the last `send` call.
 /// Previously received data is discarded
 ///
-/// - Data is only guaranteed to be clocked out when the `read` call succeeds.
+/// - Data is only guaranteed to be clocked out when the `try_read` call succeeds.
 /// The slave select line shouldn't be released before that.
 ///
 /// - Some SPIs can work with 8-bit *and* 16-bit words. You can overload this trait with different

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -13,6 +13,9 @@ use nb;
 /// - `read` calls only return the data received with the last `send` call.
 /// Previously received data is discarded
 ///
+/// - Data is only guaranteed to be clocked out when the `read` call succeeds.
+/// The slave select line shouldn't be released before that.
+///
 /// - Some SPIs can work with 8-bit *and* 16-bit words. You can overload this trait with different
 /// `Word` types to allow operation in both modes.
 pub trait FullDuplex<Word> {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -10,6 +10,9 @@ use nb;
 ///
 /// - Due to how full duplex SPI works each `read` call must be preceded by a `send` call.
 ///
+/// - `read` calls only return the data received with the last `send` call.
+/// Previously received data is discarded
+///
 /// - Some SPIs can work with 8-bit *and* 16-bit words. You can overload this trait with different
 /// `Word` types to allow operation in both modes.
 pub trait FullDuplex<Word> {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -10,7 +10,7 @@ use nb;
 ///
 /// - Due to how full duplex SPI works each `try_read` call must be preceded by a `try_send` call.
 ///
-/// - `try_read` calls only return the data received with the last `send` call.
+/// - `try_read` calls only return the data received with the last `try_send` call.
 /// Previously received data is discarded
 ///
 /// - Data is only guaranteed to be clocked out when the `try_read` call succeeds.


### PR DESCRIPTION
It should only be able to read the data returned by the last write call. Otherwise the overflow handling isn't really possible when doing only write calls (at least on stm32f0). @therealprof and me came to this conclusion after chatting on irc that this is the intended usage of this api.