### PR TITLE
Add non-blocking spi::Send trait

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -28,6 +28,8 @@ pub use digital::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPi
 pub use serial::Read as _embedded_hal_serial_Read;
 pub use serial::Write as _embedded_hal_serial_Write;
 pub use spi::FullDuplex as _embedded_hal_spi_FullDuplex;
+#[cfg(feature = "unproven")]
+pub use spi::Send as _embedded_hal_spi_Send;
 pub use timer::CountDown as _embedded_hal_timer_CountDown;
 #[cfg(feature = "unproven")]
 pub use watchdog::Watchdog as _embedded_hal_watchdog_Watchdog;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -42,7 +42,7 @@ pub trait Send<Word> {
     fn send(&mut self, word: Word) -> nb::Result<(), Self::Error>;
 
     /// Ensures that none of the previously written words are still buffered
-    fn flush(&mut self) -> nb::Result<(), Self::Error>;
+    fn completed(&mut self) -> nb::Result<(), Self::Error>;
 }
 
 /// Write (master mode)

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -31,6 +31,8 @@ pub trait FullDuplex<Word> {
 /// # Notes
 ///
 /// - It's the task of the user of this interface to manage the slave select lines
+///
+/// - The slave select line shouldn't be released before the `flush` call succeeds
 #[cfg(feature = "unproven")]
 pub trait Send<Word> {
     /// An enumeration of SPI errors
@@ -38,6 +40,9 @@ pub trait Send<Word> {
 
     /// Sends a word to the slave
     fn send(&mut self, word: Word) -> nb::Result<(), Self::Error>;
+
+    /// Ensures that none of the previously written words are still buffered
+    fn flush(&mut self) -> nb::Result<(), Self::Error>;
 }
 
 /// Write (master mode)

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -26,6 +26,52 @@ pub trait FullDuplex<Word> {
     fn send(&mut self, word: Word) -> nb::Result<(), Self::Error>;
 }
 
+/// Write (master mode)
+///
+/// # Notes
+///
+/// - It's the task of the user of this interface to manage the slave select lines
+#[cfg(feature = "unproven")]
+pub trait Send<Word> {
+    /// An enumeration of SPI errors
+    type Error;
+
+    /// Sends a word to the slave
+    fn send(&mut self, word: Word) -> nb::Result<(), Self::Error>;
+}
+
+/// Write (master mode)
+#[cfg(feature = "unproven")]
+pub mod full_duplex {
+    /// Default implementation of `spi::FullDuplex<W>` for implementers of
+    /// `spi::Send<W>`
+    ///
+    /// Also needs a `send` method to return the byte read during the last send
+    pub trait Default<W>: ::spi::Send<W> {
+        /// Reads the word stored in the shift register
+        ///
+        /// **NOTE** A word must be sent to the slave before attempting to call this
+        /// method.
+        fn read(&mut self) -> nb::Result<W, Self::Error>;
+    }
+
+    impl<W, S> ::spi::FullDuplex<W> for S
+    where
+        S: Default<W>,
+        W: Clone,
+    {
+        type Error = S::Error;
+
+        fn read(&mut self) -> nb::Result<W, Self::Error> {
+            self.read()
+        }
+
+        fn send(&mut self, word: W) -> nb::Result<(), Self::Error> {
+            self.send(word)
+        }
+    }
+}
+
 /// Clock polarity
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Polarity {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -47,33 +47,14 @@ pub trait Send<Word> {
 
 /// Write (master mode)
 #[cfg(feature = "unproven")]
-pub mod full_duplex {
-    /// Default implementation of `spi::FullDuplex<W>` for implementers of
-    /// `spi::Send<W>`
-    ///
-    /// Also needs a `send` method to return the byte read during the last send
-    pub trait Default<W>: ::spi::Send<W> {
-        /// Reads the word stored in the shift register
-        ///
-        /// **NOTE** A word must be sent to the slave before attempting to call this
-        /// method.
-        fn read(&mut self) -> nb::Result<W, Self::Error>;
+impl<W, E> Send<W> for FullDuplex<W, Error = E> {
+    type Error = E;
+    fn send(&mut self, word: W) -> nb::Result<(), Self::Error> {
+        self.send(word)
     }
 
-    impl<W, S> ::spi::FullDuplex<W> for S
-    where
-        S: Default<W>,
-        W: Clone,
-    {
-        type Error = S::Error;
-
-        fn read(&mut self) -> nb::Result<W, Self::Error> {
-            self.read()
-        }
-
-        fn send(&mut self, word: W) -> nb::Result<(), Self::Error> {
-            self.send(word)
-        }
+    fn completed(&mut self) -> nb::Result<(), Self::Error> {
+        self.read().map(|_| ())
     }
 }
 


### PR DESCRIPTION
Also add a default implementation for FullDuplex, that only needs an additional read function. Implies some constraints resulting from #120.

I also want to do an spi::Read trait, but the api seems less clear cut, as you have to start an spi transaction and read it at a later time, so two distinct things.