### PR TITLE
Derive Eq for the SPI enums

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -27,7 +27,7 @@ pub trait FullDuplex<Word> {
 }
 
 /// Clock polarity
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Polarity {
     /// Clock signal low when idle
     IdleLow,
@@ -36,7 +36,7 @@ pub enum Polarity {
 }
 
 /// Clock phase
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Phase {
     /// Data in "captured" on the first clock transition
     CaptureOnFirstTransition,
@@ -45,7 +45,7 @@ pub enum Phase {
 }
 
 /// SPI mode
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Mode {
     /// Clock polarity
     pub polarity: Polarity,


### PR DESCRIPTION
This allows matching against these in downstream crates, and seems like
a logical addition to the existing PartialEq (since this doesn't contain
any floats, obviously).