### PR TITLE
Release version 0.2.3-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal"
 readme = "README.md"
 repository = "https://github.com/japaric/embedded-hal"
-version = "0.2.2"
+version = "0.2.3-rc.1"
 
 [dependencies.void]
 default-features = false


### PR DESCRIPTION
hmm so cargo-release failed at pushing to master, but still pushed to [crates.io](https://crates.io/crates/embedded-hal/0.2.3-rc.1), might have to open a bug report there 😅

see also: https://github.com/rust-embedded/embedded-hal/issues/92#issuecomment-480917982