### PR TITLE
PwmPin: allow get_duty to return the old value for some time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -905,6 +905,9 @@ pub trait PwmPin {
     fn enable(&mut self);
 
     /// Returns the current duty cycle
+    ///
+    /// While the pin is transitioning to the new duty cycle after a `set_duty` call, this may
+    /// return the old or the new duty cycle depending on the implementation.
     fn get_duty(&self) -> Self::Duty;
 
     /// Returns the maximum duty cycle value


### PR DESCRIPTION
PWM is often implemented in a buffered way to allow glitch-free operation; as a result, implementing a strict "you get what you last set" is not feasible for some implementations.

---

This change allows the implementation to decide which value to return for `get_duty` while it is being changed. The current wording is "current duty cycle", which seems to be quite clear but deviates from the usual semantics of getters and setters in a way that can lead to different interpretations.

In particular, the EFM32 implementation gives the old value until the cycle has actually been changed (at least since a semi-related WIP bugfix) -- but it seems to me that it makes sense to allow that given how it can be implemented, especially considering that basic embedded-hal traits should be widely implementable.

Alternatives:
* Prescribe "it's always the current duty cycle"
  * If that's the original intent, I'd be happy to change this PR to instead add "Note that setting a PWM duty cycle may not take effect immediately. After `set_duty` has been called, this reports the old duty cycle until the change has been executed." or similar.
  * I don't know whether it can be implemented like that everywhere.
* Prescribe "get after set gives last set value"
  * This may not be possible to implement on all platforms while keeping PwmPin zerosized
* Make set_duty block (or nonblockingly refuse access to the peripheral while it's being changed)