### PR TITLE
Remove #[deny(warnings)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,7 +683,6 @@
 //! ```
 
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![no_std]
 
 #[macro_use]


### PR DESCRIPTION
It's an antipattern, see https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md and https://github.com/rust-embedded/linux-embedded-hal/pull/17