### PR TITLE
Silence warning for `impl Write` in rust-nightly.

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -3,12 +3,13 @@
 //! TODO write example of usage
 use core::fmt::{Result, Write};
 
-impl<Word, Error> Write for ::serial::Write<Word, Error=Error>
+impl<Word, Error> Write for dyn (::serial::Write<Word, Error = Error>)
 where
     Word: From<u8>,
 {
     fn write_str(&mut self, s: &str) -> Result {
-        let _ = s.as_bytes()
+        let _ = s
+            .as_bytes()
             .into_iter()
             .map(|c| block!(self.write(Word::from(*c))))
             .last();


### PR DESCRIPTION
Nightly as of, at least `0beb2ba16 2019-07-02` requires the `dyn` keyword on the Write trait impl.