### PR TITLE
Fix error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,6 @@ readme = "README.md"
 repository = "https://github.com/japaric/embedded-hal"
 version = "0.2.3"
 
-[dependencies.void]
-default-features = false
-version = "1.0.2"
-
 [dependencies.nb]
 version = "0.1.1"
 

--- a/src/digital/v2.rs
+++ b/src/digital/v2.rs
@@ -59,7 +59,7 @@ pub trait ToggleableOutputPin {
 /// ```
 /// use embedded_hal::digital::v2::{OutputPin, StatefulOutputPin, ToggleableOutputPin};
 /// use embedded_hal::digital::v2::toggleable;
-/// use core::convert::Infallible;
+/// use std::convert::Infallible;
 ///
 /// /// A virtual output pin that exists purely in software
 /// struct MyPin {

--- a/src/digital/v2.rs
+++ b/src/digital/v2.rs
@@ -59,6 +59,7 @@ pub trait ToggleableOutputPin {
 /// ```
 /// use embedded_hal::digital::v2::{OutputPin, StatefulOutputPin, ToggleableOutputPin};
 /// use embedded_hal::digital::v2::toggleable;
+/// use core::convert::Infallible;
 ///
 /// /// A virtual output pin that exists purely in software
 /// struct MyPin {
@@ -66,7 +67,7 @@ pub trait ToggleableOutputPin {
 /// }
 ///
 /// impl OutputPin for MyPin {
-///    type Error = void::Void;
+///    type Error = Infallible;
 ///
 ///    fn set_low(&mut self) -> Result<(), Self::Error> {
 ///        self.state = false;

--- a/src/digital/v2_compat.rs
+++ b/src/digital/v2_compat.rs
@@ -32,6 +32,8 @@
 //! ```
 //! 
 
+use core::convert::Infallible;
+
 #[allow(deprecated)]
 use super::v1;
 use super::v2;
@@ -42,8 +44,7 @@ impl <T> v2::OutputPin for T
 where
     T: v1::OutputPin,
 {
-    // TODO: update to ! when never_type is stabilized
-    type Error = ();
+    type Error = Infallible;
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
         Ok(self.set_low())
@@ -81,8 +82,7 @@ impl <T> v2::InputPin for T
 where
     T: v1::InputPin
 {
-    // TODO: update to ! when never_type is stabilized
-    type Error = ();
+    type Error = Infallible;
 
     fn is_low(&self) -> Result<bool, Self::Error> {
         Ok(self.is_low())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,20 +90,19 @@
 //! [`WouldBlock`]: https://docs.rs/nb/0.1.0/nb/enum.Error.html
 //!
 //! Some traits, like the one shown below, may expose possibly blocking APIs that can't fail. In
-//! those cases `nb::Result<_, Void>` is used.
+//! those cases `nb::Result<_, Infallible>` is used.
 //!
 //! ```
 //! extern crate nb;
-//! extern crate void;
 //!
-//! use void::Void;
+//! use core::convert::Infallible;
 //!
 //! /// A count down timer
 //! pub trait CountDown {
 //!     // ..
 //!
 //!     /// "waits" until the count down is over
-//!     fn wait(&mut self) -> nb::Result<(), Void>;
+//!     fn wait(&mut self) -> nb::Result<(), Infallible>;
 //! }
 //!
 //! # fn main() {}
@@ -223,11 +222,10 @@
 //! # }
 //!
 //! # mod stm32f30x_hal {
-//! #     extern crate void;
-//! #     use self::void::Void;
+//! #     use core::convert::Infallible;
 //! #     pub struct Serial1;
 //! #     impl Serial1 {
-//! #         pub fn write(&mut self, _: u8) -> ::nb::Result<(), Void> {
+//! #         pub fn write(&mut self, _: u8) -> ::nb::Result<(), Infallible> {
 //! #             Ok(())
 //! #         }
 //! #     }
@@ -242,7 +240,6 @@
 //! ```
 //! extern crate embedded_hal as hal;
 //! extern crate futures;
-//! extern crate void;
 //!
 //! #[macro_use(try_nb)]
 //! extern crate nb;
@@ -255,12 +252,12 @@
 //! };
 //! use futures::future::Loop;
 //! use stm32f30x_hal::{Led, Serial1, Timer6};
-//! use void::Void;
+//! use core::convert::Infallible;
 //!
 //! /// `futures` version of `CountDown.wait`
 //! ///
 //! /// This returns a future that must be polled to completion
-//! fn wait<T>(mut timer: T) -> impl Future<Item = T, Error = Void>
+//! fn wait<T>(mut timer: T) -> impl Future<Item = T, Error = Infallible>
 //! where
 //!     T: hal::timer::CountDown,
 //! {
@@ -342,32 +339,31 @@
 //!
 //!     // Event loop
 //!     loop {
-//!         blinky.poll().unwrap(); // NOTE(unwrap) E = Void
+//!         blinky.poll().unwrap(); // NOTE(unwrap) E = Infallible
 //!         loopback.poll().unwrap();
 //! #       break;
 //!     }
 //! }
 //!
 //! # mod stm32f30x_hal {
-//! #     extern crate void;
-//! #     use self::void::Void;
+//! #     use core::convert::Infallible;
 //! #     pub struct Timer6;
 //! #     impl ::hal::timer::CountDown for Timer6 {
 //! #         type Time = ();
 //! #
 //! #         fn start<T>(&mut self, _: T) where T: Into<()> {}
-//! #         fn wait(&mut self) -> ::nb::Result<(), Void> { Err(::nb::Error::WouldBlock) }
+//! #         fn wait(&mut self) -> ::nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
 //! #     }
 //! #
 //! #     pub struct Serial1;
 //! #     impl ::hal::serial::Read<u8> for Serial1 {
-//! #         type Error = Void;
-//! #         fn read(&mut self) -> ::nb::Result<u8, Void> { Err(::nb::Error::WouldBlock) }
+//! #         type Error = Infallible;
+//! #         fn read(&mut self) -> ::nb::Result<u8, Infallible> { Err(::nb::Error::WouldBlock) }
 //! #     }
 //! #     impl ::hal::serial::Write<u8> for Serial1 {
-//! #         type Error = Void;
-//! #         fn flush(&mut self) -> ::nb::Result<(), Void> { Err(::nb::Error::WouldBlock) }
-//! #         fn write(&mut self, _: u8) -> ::nb::Result<(), Void> { Err(::nb::Error::WouldBlock) }
+//! #         type Error = Infallible;
+//! #         fn flush(&mut self) -> ::nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
+//! #         fn write(&mut self, _: u8) -> ::nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
 //! #     }
 //! #
 //! #     pub struct Led;
@@ -418,7 +414,7 @@
 //!         loop {
 //!             // `await!` means "suspend / yield here" instead of "block until
 //!             // completion"
-//!             await!(timer.wait()).unwrap(); // NOTE(unwrap) E = Void
+//!             await!(timer.wait()).unwrap(); // NOTE(unwrap) E = Infallible
 //!
 //!             state = !state;
 //!
@@ -446,16 +442,15 @@
 //! }
 //!
 //! # mod stm32f30x_hal {
-//! #   extern crate void;
-//! #   use self::void::Void;
+//! #   use core::convert::Infallible;
 //! #   pub struct Serial1;
 //! #   impl Serial1 {
-//! #       pub fn read(&mut self) -> ::nb::Result<u8, Void> { Err(::nb::Error::WouldBlock) }
-//! #       pub fn write(&mut self, _: u8) -> ::nb::Result<(), Void> { Err(::nb::Error::WouldBlock) }
+//! #       pub fn read(&mut self) -> ::nb::Result<u8, Infallible> { Err(::nb::Error::WouldBlock) }
+//! #       pub fn write(&mut self, _: u8) -> ::nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
 //! #   }
 //! #   pub struct Timer6;
 //! #   impl Timer6 {
-//! #       pub fn wait(&mut self) -> ::nb::Result<(), Void> { Err(::nb::Error::WouldBlock) }
+//! #       pub fn wait(&mut self) -> ::nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
 //! #   }
 //! #   pub struct Led;
 //! #   impl Led {
@@ -596,14 +591,13 @@
 //! ```
 //! extern crate embedded_hal as hal;
 //! extern crate nb;
-//! extern crate void;
 //!
 //! use hal::prelude::*;
-//! use void::Void;
+//! use core::convert::Infallible;
 //!
 //! fn flush<S>(serial: &mut S, cb: &mut CircularBuffer)
 //! where
-//!     S: hal::serial::Write<u8, Error = Void>,
+//!     S: hal::serial::Write<u8, Error = Infallible>,
 //! {
 //!     loop {
 //!         if let Some(byte) = cb.peek() {
@@ -668,9 +662,9 @@
 //! # }
 //! # struct Serial1;
 //! # impl ::hal::serial::Write<u8> for Serial1 {
-//! #   type Error = Void;
-//! #   fn write(&mut self, _: u8) -> nb::Result<(), Void> { Err(::nb::Error::WouldBlock) }
-//! #   fn flush(&mut self) -> nb::Result<(), Void> { Err(::nb::Error::WouldBlock) }
+//! #   type Error = Infallible;
+//! #   fn write(&mut self, _: u8) -> nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
+//! #   fn flush(&mut self) -> nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
 //! # }
 //! # struct CircularBuffer;
 //! # impl CircularBuffer {
@@ -687,7 +681,6 @@
 
 #[macro_use]
 extern crate nb;
-extern crate void;
 
 pub mod adc;
 pub mod blocking;
@@ -731,8 +724,7 @@ pub mod watchdog;
 ///     println!("Period: {} ms", period);
 /// }
 ///
-/// # extern crate void;
-/// # use void::Void;
+/// # use core::convert::Infallible;
 /// # struct MilliSeconds(u32);
 /// # trait U32Ext { fn ms(self) -> MilliSeconds; }
 /// # impl U32Ext for u32 { fn ms(self) -> MilliSeconds { MilliSeconds(self) } }
@@ -741,9 +733,9 @@ pub mod watchdog;
 /// # impl hal::Capture for Capture1 {
 /// #     type Capture = u16;
 /// #     type Channel = Channel;
-/// #     type Error = Void;
+/// #     type Error = Infallible;
 /// #     type Time = MilliSeconds;
-/// #     fn capture(&mut self, _: Channel) -> ::nb::Result<u16, Void> { Ok(0) }
+/// #     fn capture(&mut self, _: Channel) -> ::nb::Result<u16, Infallible> { Ok(0) }
 /// #     fn disable(&mut self, _: Channel) { unimplemented!() }
 /// #     fn enable(&mut self, _: Channel) { unimplemented!() }
 /// #     fn get_resolution(&self) -> MilliSeconds { unimplemented!() }
@@ -948,8 +940,7 @@ pub trait PwmPin {
 ///     println!("Speed: {} pulses per second", speed);
 /// }
 ///
-/// # extern crate void;
-/// # use void::Void;
+/// # use core::convert::Infallible;
 /// # struct Seconds(u32);
 /// # trait U32Ext { fn s(self) -> Seconds; }
 /// # impl U32Ext for u32 { fn s(self) -> Seconds { Seconds(self) } }
@@ -963,7 +954,7 @@ pub trait PwmPin {
 /// # impl hal::timer::CountDown for Timer6 {
 /// #     type Time = Seconds;
 /// #     fn start<T>(&mut self, _: T) where T: Into<Seconds> {}
-/// #     fn wait(&mut self) -> ::nb::Result<(), Void> { Ok(()) }
+/// #     fn wait(&mut self) -> ::nb::Result<(), Infallible> { Ok(()) }
 /// # }
 /// ```
 #[cfg(feature = "unproven")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@
 //! ```
 //! extern crate nb;
 //!
+//! # use std as core;
 //! use core::convert::Infallible;
 //!
 //! /// A count down timer
@@ -222,7 +223,7 @@
 //! # }
 //!
 //! # mod stm32f30x_hal {
-//! #     use core::convert::Infallible;
+//! #     use std::convert::Infallible;
 //! #     pub struct Serial1;
 //! #     impl Serial1 {
 //! #         pub fn write(&mut self, _: u8) -> ::nb::Result<(), Infallible> {
@@ -252,7 +253,7 @@
 //! };
 //! use futures::future::Loop;
 //! use stm32f30x_hal::{Led, Serial1, Timer6};
-//! use core::convert::Infallible;
+//! use std::convert::Infallible;
 //!
 //! /// `futures` version of `CountDown.wait`
 //! ///
@@ -346,7 +347,7 @@
 //! }
 //!
 //! # mod stm32f30x_hal {
-//! #     use core::convert::Infallible;
+//! #     use std::convert::Infallible;
 //! #     pub struct Timer6;
 //! #     impl ::hal::timer::CountDown for Timer6 {
 //! #         type Time = ();
@@ -442,7 +443,7 @@
 //! }
 //!
 //! # mod stm32f30x_hal {
-//! #   use core::convert::Infallible;
+//! #   use std::convert::Infallible;
 //! #   pub struct Serial1;
 //! #   impl Serial1 {
 //! #       pub fn read(&mut self) -> ::nb::Result<u8, Infallible> { Err(::nb::Error::WouldBlock) }
@@ -589,6 +590,7 @@
 //! - Buffered serial interface with periodic flushing in interrupt handler
 //!
 //! ```
+//! # use std as core;
 //! extern crate embedded_hal as hal;
 //! extern crate nb;
 //!
@@ -724,7 +726,7 @@ pub mod watchdog;
 ///     println!("Period: {} ms", period);
 /// }
 ///
-/// # use core::convert::Infallible;
+/// # use std::convert::Infallible;
 /// # struct MilliSeconds(u32);
 /// # trait U32Ext { fn ms(self) -> MilliSeconds; }
 /// # impl U32Ext for u32 { fn ms(self) -> MilliSeconds { MilliSeconds(self) } }
@@ -940,7 +942,7 @@ pub trait PwmPin {
 ///     println!("Speed: {} pulses per second", speed);
 /// }
 ///
-/// # use core::convert::Infallible;
+/// # use std::convert::Infallible;
 /// # struct Seconds(u32);
 /// # trait U32Ext { fn s(self) -> Seconds; }
 /// # impl U32Ext for u32 { fn s(self) -> Seconds { Seconds(self) } }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -40,7 +40,7 @@ use core::convert::Infallible;
 ///     Led.off();
 /// }
 ///
-/// # use core::convert::Infallible;
+/// # use std::convert::Infallible;
 /// # struct Seconds(u32);
 /// # trait U32Ext { fn s(self) -> Seconds; }
 /// # impl U32Ext for u32 { fn s(self) -> Seconds { Seconds(self) } }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,7 +1,7 @@
 //! Timers
 
 use nb;
-use void::Void;
+use core::convert::Infallible;
 
 /// A count down timer
 ///
@@ -40,8 +40,7 @@ use void::Void;
 ///     Led.off();
 /// }
 ///
-/// # extern crate void;
-/// # use void::Void;
+/// # use core::convert::Infallible;
 /// # struct Seconds(u32);
 /// # trait U32Ext { fn s(self) -> Seconds; }
 /// # impl U32Ext for u32 { fn s(self) -> Seconds { Seconds(self) } }
@@ -54,7 +53,7 @@ use void::Void;
 /// # impl hal::timer::CountDown for Timer6 {
 /// #     type Time = Seconds;
 /// #     fn start<T>(&mut self, _: T) where T: Into<Seconds> {}
-/// #     fn wait(&mut self) -> ::nb::Result<(), Void> { Ok(()) }
+/// #     fn wait(&mut self) -> ::nb::Result<(), Infallible> { Ok(()) }
 /// # }
 /// ```
 pub trait CountDown {
@@ -74,7 +73,7 @@ pub trait CountDown {
     /// finishes.
     /// - Otherwise the behavior of calling `wait` after the last call returned `Ok` is UNSPECIFIED.
     /// Implementers are suggested to panic on this scenario to signal a programmer error.
-    fn wait(&mut self) -> nb::Result<(), Void>;
+    fn wait(&mut self) -> nb::Result<(), Infallible>;
 }
 
 /// Marker trait that indicates that a timer is periodic


### PR DESCRIPTION
`core::convert::Infallible` was stabilized in 1.34.0. This PR replaces `Void` and `()` error types with `Infallible`.

Note that this is a breaking change.