### PR TITLE
TriStatePin proposal

### DIFF
--- a/src/digital/v2.rs
+++ b/src/digital/v2.rs
@@ -136,3 +136,34 @@ pub trait InputPin {
     /// Is the input pin low?
     fn is_low(&self) -> Result<bool, Self::Error>;
 }
+
+/// The states of a tri-state pin
+///
+/// *This type is available if embedded-hal is built with the `"unproven"` feature.*
+#[cfg(feature = "unproven")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum PinState {
+    /// Pin state low
+    Low,
+    /// Pin state high
+    High,
+    /// The pin is set to high impedance mode
+    Floating,
+}
+
+/// A tri-state (low, high, floating) pin
+///
+/// *This trait is available if embedded-hal is built with the `"unproven"` feature.*
+#[cfg(feature = "unproven")]
+pub trait TriStatePin {
+    /// Error type
+    type Error;
+
+    /// Changes the state of the pin
+    fn set(&mut self, state: PinState) -> Result<(), Self::Error>;
+
+    /// Gets the state of the pin.
+    ///
+    /// *NOTE* this does *not* read the electrical state of the pin
+    fn state(&self) -> Result<PinState, Self::Error>;
+}

--- a/src/digital/v2.rs
+++ b/src/digital/v2.rs
@@ -141,7 +141,7 @@ pub trait InputPin {
 ///
 /// *This type is available if embedded-hal is built with the `"unproven"` feature.*
 #[cfg(feature = "unproven")]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PinState {
     /// Pin state low
     Low,


### PR DESCRIPTION
I have simply added the enum variant as per the proposal in #31, since it seemed to be the most popular. 

I am in the middle of implementing a [charlieplexing crate](https://github.com/osannolik/charlieplexing-rs) for use in a [project](https://github.com/osannolik/strobo/tree/master/sw-rust/stroborust) of mine (custom board using an stm32l051) and would therefore need this trait. 

To try it out I implemented the trait for the stm32l0xx-hal in a [branch](https://github.com/osannolik/stm32l0xx-hal/tree/tristate) together with an example application, and got the charlieplexing working as a proof of concept on my custom board driving 30 leds. 

The charlieplexing crate is far from done, but I think the trait is going to work great, so to get the wheels spinning and allow for more opinions, I thought I might as well open a pull request right away...