### PR TITLE
Make the digital::{v1, v2}::InputPin traits proven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Changed
-
+- The current versions of `InputPin` have been proven. These are `digital::v1::InputPin` 
+  and `digital::v2::InputPin`.
 
 ## [v0.2.3] - 2019-05-09
 

--- a/src/digital/v1.rs
+++ b/src/digital/v1.rs
@@ -131,11 +131,8 @@ pub mod toggleable {
 
 /// Single digital input pin
 ///
-/// *This trait is available if embedded-hal is built with the `"unproven"` feature.*
-///
 /// *This version of the trait is now deprecated. Please use the new `InputPin` trait in
 /// `digital::v2::InputPin`*.
-#[cfg(feature = "unproven")]
 pub trait InputPin {
     /// Is the input pin high?
     fn is_high(&self) -> bool;

--- a/src/digital/v1_compat.rs
+++ b/src/digital/v1_compat.rs
@@ -108,14 +108,10 @@ where
 
 /// Wrapper to allow fallible `v2::InputPin` traits to be converted to `v1::InputPin` traits
 /// where errors will panic.
-///
-/// Available behind `"unproven"` feature because `v1::InputPin` is
-#[cfg(feature = "unproven")]
 pub struct OldInputPin<T> {
     pin: T,
 }
 
-#[cfg(feature = "unproven")]
 impl <T, E> OldInputPin<T>
 where
     T: v2::OutputPin<Error=E>,
@@ -128,7 +124,6 @@ where
 
 }
 
-#[cfg(feature = "unproven")]
 impl <T, E> From<T> for OldInputPin<T>
 where
     T: v2::InputPin<Error=E>,
@@ -141,9 +136,6 @@ where
 
 /// Implementation of `v1::InputPin` trait for `v2::InputPin` fallible pins
 /// where errors will panic.
-///
-/// Available behind `"unproven"` feature because `v1::InputPin` is
-#[cfg(feature = "unproven")]
 #[allow(deprecated)]
 impl <T, E> v1::InputPin for OldInputPin<T>
 where
@@ -228,15 +220,12 @@ mod tests {
         o.set_high();
     }
 
-    #[cfg(feature = "unproven")]
     use crate::digital::v1::InputPin;
 
-    #[cfg(feature = "unproven")]
     struct NewInputPinImpl {
         state: Result<bool, ()>,
     }
 
-    #[cfg(feature = "unproven")]
     impl v2::InputPin for NewInputPinImpl {
         type Error = ();
 
@@ -248,13 +237,11 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "unproven")]
     #[allow(deprecated)]
     struct OldInputPinConsumer<T: v1::InputPin> {
         _pin: T,
     }
 
-    #[cfg(feature = "unproven")]
     #[allow(deprecated)]
     impl <T>OldInputPinConsumer<T> 
     where T: v1::InputPin 
@@ -264,14 +251,12 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "unproven")]
     #[test]
     fn v1_v2_input_explicit() {
         let i = NewInputPinImpl{state: Ok(false)};
         let _c: OldInputPinConsumer<OldInputPin<_>> = OldInputPinConsumer::new(i.into());
     }
 
-    #[cfg(feature = "unproven")]
     #[test]
     fn v1_v2_input_state() {
         let i:  OldInputPin<_> = NewInputPinImpl{state: Ok(false)}.into();
@@ -280,7 +265,6 @@ mod tests {
         assert_eq!(i.is_high(), false);
     }
 
-    #[cfg(feature = "unproven")]
     #[test]
     #[should_panic]
     fn v1_v2_input_panic() {

--- a/src/digital/v1_compat.rs
+++ b/src/digital/v1_compat.rs
@@ -108,6 +108,8 @@ where
 
 /// Wrapper to allow fallible `v2::InputPin` traits to be converted to `v1::InputPin` traits
 /// where errors will panic.
+///
+/// Available behind `"unproven"` feature because `v1::InputPin` is
 #[cfg(feature = "unproven")]
 pub struct OldInputPin<T> {
     pin: T,
@@ -139,6 +141,8 @@ where
 
 /// Implementation of `v1::InputPin` trait for `v2::InputPin` fallible pins
 /// where errors will panic.
+///
+/// Available behind `"unproven"` feature because `v1::InputPin` is
 #[cfg(feature = "unproven")]
 #[allow(deprecated)]
 impl <T, E> v1::InputPin for OldInputPin<T>

--- a/src/digital/v2.rs
+++ b/src/digital/v2.rs
@@ -124,9 +124,6 @@ pub mod toggleable {
 }
 
 /// Single digital input pin
-///
-/// *This trait is available if embedded-hal is built with the `"unproven"` feature.*
-#[cfg(feature = "unproven")]
 pub trait InputPin {
     /// Error type
     type Error;

--- a/src/digital/v2_compat.rs
+++ b/src/digital/v2_compat.rs
@@ -76,9 +76,6 @@ where
 impl<T> v2::toggleable::Default for T where T: v1::toggleable::Default {}
 
 /// Implementation of fallible `v2::InputPin` for `v1::InputPin` digital traits
-///
-/// Available behind `"unproven"` feature because `v1::InputPin` is
-#[cfg(feature = "unproven")]
 #[allow(deprecated)]
 impl <T> v2::InputPin for T
 where
@@ -178,13 +175,11 @@ mod tests {
         assert_eq!(o.state, false);
     }
 
-    #[cfg(feature = "unproven")]
     #[allow(deprecated)]
     struct OldInputPinImpl { 
         state: bool
     }
 
-    #[cfg(feature = "unproven")]
     #[allow(deprecated)]
     impl v1::InputPin for OldInputPinImpl {
         fn is_low(&self) -> bool {
@@ -195,12 +190,10 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "unproven")]
     struct NewInputPinConsumer<T: v2::InputPin> {
         _pin: T,
     }
 
-    #[cfg(feature = "unproven")]
     impl <T>NewInputPinConsumer<T> 
     where T: v2::InputPin {
         pub fn new(pin: T) -> NewInputPinConsumer<T> {
@@ -208,14 +201,12 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "unproven")]
     #[test]
     fn v2_v1_input_implicit() {
         let i = OldInputPinImpl{state: false};
         let _c = NewInputPinConsumer::new(i);
     }
 
-    #[cfg(feature = "unproven")]
     #[test]
     fn v2_v1_input_state() {
         let mut i = OldInputPinImpl{state: false};

--- a/src/digital/v2_compat.rs
+++ b/src/digital/v2_compat.rs
@@ -76,6 +76,8 @@ where
 impl<T> v2::toggleable::Default for T where T: v1::toggleable::Default {}
 
 /// Implementation of fallible `v2::InputPin` for `v1::InputPin` digital traits
+///
+/// Available behind `"unproven"` feature because `v1::InputPin` is
 #[cfg(feature = "unproven")]
 #[allow(deprecated)]
 impl <T> v2::InputPin for T


### PR DESCRIPTION
See #41 

Previous attempt : #102 