### PR TITLE
Change library edition to 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
 categories = ["asynchronous", "embedded", "hardware-support", "no-std"]
 description = " A Hardware Abstraction Layer (HAL) for embedded systems "
 documentation = "https://docs.rs/embedded-hal"
+edition = "2018"
 keywords = ["hal", "IO"]
 license = "MIT OR Apache-2.0"
 name = "embedded-hal"

--- a/src/blocking/serial.rs
+++ b/src/blocking/serial.rs
@@ -29,9 +29,9 @@ pub mod write {
     ///
     /// [`serial::Write`]: ../../serial/trait.Write.html
     /// [`blocking::serial::Write`]: ../trait.Write.html
-    pub trait Default<Word>: ::serial::Write<Word> {}
+    pub trait Default<Word>: crate::serial::Write<Word> {}
 
-    impl<S, Word> ::blocking::serial::Write<Word> for S
+    impl<S, Word> crate::blocking::serial::Write<Word> for S
     where
         S: Default<Word>,
         Word: Clone,

--- a/src/blocking/spi.rs
+++ b/src/blocking/spi.rs
@@ -34,9 +34,9 @@ pub trait WriteIter<W> {
 pub mod transfer {
     /// Default implementation of `blocking::spi::Transfer<W>` for implementers of
     /// `spi::FullDuplex<W>`
-    pub trait Default<W>: ::spi::FullDuplex<W> {}
+    pub trait Default<W>: crate::spi::FullDuplex<W> {}
 
-    impl<W, S> ::blocking::spi::Transfer<W> for S
+    impl<W, S> crate::blocking::spi::Transfer<W> for S
     where
         S: Default<W>,
         W: Clone,
@@ -57,9 +57,9 @@ pub mod transfer {
 /// Blocking write
 pub mod write {
     /// Default implementation of `blocking::spi::Write<W>` for implementers of `spi::FullDuplex<W>`
-    pub trait Default<W>: ::spi::FullDuplex<W> {}
+    pub trait Default<W>: crate::spi::FullDuplex<W> {}
 
-    impl<W, S> ::blocking::spi::Write<W> for S
+    impl<W, S> crate::blocking::spi::Write<W> for S
     where
         S: Default<W>,
         W: Clone,
@@ -82,9 +82,9 @@ pub mod write {
 pub mod write_iter {
     /// Default implementation of `blocking::spi::WriteIter<W>` for implementers of
     /// `spi::FullDuplex<W>`
-    pub trait Default<W>: ::spi::FullDuplex<W> {}
+    pub trait Default<W>: crate::spi::FullDuplex<W> {}
 
-    impl<W, S> ::blocking::spi::WriteIter<W> for S
+    impl<W, S> crate::blocking::spi::WriteIter<W> for S
     where
         S: Default<W>,
         W: Clone,

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -3,7 +3,7 @@
 //! TODO write example of usage
 use core::fmt::{Result, Write};
 
-impl<Word, Error> Write for ::serial::Write<Word, Error=Error>
+impl<Word, Error> Write for dyn (crate::serial::Write<Word, Error=Error>)
 where
     Word: From<u8>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 //! extern crate nb;
 //!
 //! # use std as core;
-//! use core::convert::Infallible;
+//! use ::core::convert::Infallible;
 //!
 //! /// A count down timer
 //! pub trait CountDown {
@@ -385,7 +385,7 @@
 //!
 //! extern crate embedded_hal as hal;
 //!
-//! #[macro_use(await)]
+//! #[macro_use(r#await)]
 //! extern crate nb;
 //!
 //! use std::ops::Generator;
@@ -415,7 +415,7 @@
 //!         loop {
 //!             // `await!` means "suspend / yield here" instead of "block until
 //!             // completion"
-//!             await!(timer.wait()).unwrap(); // NOTE(unwrap) E = Infallible
+//!             nb::r#await!(timer.wait()).unwrap(); // NOTE(unwrap) E = Infallible
 //!
 //!             state = !state;
 //!
@@ -429,8 +429,8 @@
 //!
 //!     let mut loopback = (move || {
 //!         loop {
-//!             let byte = await!(serial.read()).unwrap();
-//!             await!(serial.write(byte)).unwrap();
+//!             let byte = nb::r#await!(serial.read()).unwrap();
+//!             nb::r#await!(serial.write(byte)).unwrap();
 //!         }
 //!     });
 //!
@@ -557,7 +557,7 @@
 //! #![feature(generator_trait)]
 //!
 //! extern crate embedded_hal as hal;
-//! #[macro_use(await)]
+//! #[macro_use(r#await)]
 //! extern crate nb;
 //!
 //! use std::ops::Generator;
@@ -576,8 +576,8 @@
 //!     move || {
 //!         let n = buffer.len();
 //!         for i in 0..n {
-//!             await!(spi.send(buffer[i]))?;
-//!             buffer[i] = await!(spi.read())?;
+//!             nb::r#await!(spi.send(buffer[i]))?;
+//!             buffer[i] = nb::r#await!(spi.read())?;
 //!         }
 //!
 //!         Ok((spi, buffer))
@@ -595,7 +595,7 @@
 //! extern crate nb;
 //!
 //! use hal::prelude::*;
-//! use core::convert::Infallible;
+//! use ::core::convert::Infallible;
 //!
 //! fn flush<S>(serial: &mut S, cb: &mut CircularBuffer)
 //! where

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,43 +4,43 @@
 //! performing a glob import.
 
 #[cfg(feature = "unproven")]
-pub use adc::OneShot as _embedded_hal_adc_OneShot;
-pub use blocking::delay::DelayMs as _embedded_hal_blocking_delay_DelayMs;
-pub use blocking::delay::DelayUs as _embedded_hal_blocking_delay_DelayUs;
-pub use blocking::i2c::{
+pub use crate::adc::OneShot as _embedded_hal_adc_OneShot;
+pub use crate::blocking::delay::DelayMs as _embedded_hal_blocking_delay_DelayMs;
+pub use crate::blocking::delay::DelayUs as _embedded_hal_blocking_delay_DelayUs;
+pub use crate::blocking::i2c::{
     Read as _embedded_hal_blocking_i2c_Read, Write as _embedded_hal_blocking_i2c_Write,
     WriteRead as _embedded_hal_blocking_i2c_WriteRead,
 };
 #[cfg(feature = "unproven")]
-pub use blocking::rng::Read as _embedded_hal_blocking_rng_Read;
-pub use blocking::serial::Write as _embedded_hal_blocking_serial_Write;
-pub use blocking::spi::{
+pub use crate::blocking::rng::Read as _embedded_hal_blocking_rng_Read;
+pub use crate::blocking::serial::Write as _embedded_hal_blocking_serial_Write;
+pub use crate::blocking::spi::{
     Transfer as _embedded_hal_blocking_spi_Transfer, Write as _embedded_hal_blocking_spi_Write,
 };
 #[allow(deprecated)]
 #[cfg(feature = "unproven")]
-pub use digital::InputPin as _embedded_hal_digital_InputPin;
+pub use crate::digital::InputPin as _embedded_hal_digital_InputPin;
 #[allow(deprecated)]
-pub use digital::OutputPin as _embedded_hal_digital_OutputPin;
+pub use crate::digital::OutputPin as _embedded_hal_digital_OutputPin;
 #[cfg(feature = "unproven")]
 #[allow(deprecated)]
-pub use digital::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
+pub use crate::digital::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
 #[cfg(feature = "unproven")]
-pub use rng::Read as _embedded_hal_rng_Read;
-pub use serial::Read as _embedded_hal_serial_Read;
-pub use serial::Write as _embedded_hal_serial_Write;
-pub use spi::FullDuplex as _embedded_hal_spi_FullDuplex;
-pub use timer::CountDown as _embedded_hal_timer_CountDown;
+pub use crate::rng::Read as _embedded_hal_rng_Read;
+pub use crate::serial::Read as _embedded_hal_serial_Read;
+pub use crate::serial::Write as _embedded_hal_serial_Write;
+pub use crate::spi::FullDuplex as _embedded_hal_spi_FullDuplex;
+pub use crate::timer::CountDown as _embedded_hal_timer_CountDown;
 #[cfg(feature = "unproven")]
-pub use watchdog::Watchdog as _embedded_hal_watchdog_Watchdog;
+pub use crate::watchdog::Watchdog as _embedded_hal_watchdog_Watchdog;
 #[cfg(feature = "unproven")]
-pub use watchdog::WatchdogDisable as _embedded_hal_watchdog_WatchdogDisable;
+pub use crate::watchdog::WatchdogDisable as _embedded_hal_watchdog_WatchdogDisable;
 #[cfg(feature = "unproven")]
-pub use watchdog::WatchdogEnable as _embedded_hal_watchdog_WatchdogEnable;
+pub use crate::watchdog::WatchdogEnable as _embedded_hal_watchdog_WatchdogEnable;
 #[cfg(feature = "unproven")]
-pub use Capture as _embedded_hal_Capture;
+pub use crate::Capture as _embedded_hal_Capture;
 #[cfg(feature = "unproven")]
-pub use Pwm as _embedded_hal_Pwm;
-pub use PwmPin as _embedded_hal_PwmPin;
+pub use crate::Pwm as _embedded_hal_Pwm;
+pub use crate::PwmPin as _embedded_hal_PwmPin;
 #[cfg(feature = "unproven")]
-pub use Qei as _embedded_hal_Qei;
+pub use crate::Qei as _embedded_hal_Qei;


### PR DESCRIPTION
Crate edition updated to 2018. Any fixes are applied by `cargo fix` utility. It includes same part with #162 because in 2018 this warnings are errors.
Code formatting will be introduced in another PR(such as #166)