### PR TITLE
Fix failed run test without unproven feature

### DIFF
--- a/src/digital/v2_compat.rs
+++ b/src/digital/v2_compat.rs
@@ -114,6 +114,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "unproven")]
     #[allow(deprecated)]
     impl v1::StatefulOutputPin for OldOutputPinImpl {
         fn is_set_low(&self) -> bool {
@@ -125,6 +126,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "unproven")]
     #[allow(deprecated)]
     impl v1::toggleable::Default for OldOutputPinImpl {}
 
@@ -139,10 +141,12 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "unproven")]
     struct NewToggleablePinConsumer<T: v2::ToggleableOutputPin> {
         _pin: T,
     }
 
+    #[cfg(feature = "unproven")]
     impl<T> NewToggleablePinConsumer<T>
     where
         T: v2::ToggleableOutputPin,
@@ -152,6 +156,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "unproven")]
     #[test]
     fn v2_v1_toggleable_implicit() {
         let i = OldOutputPinImpl { state: false };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@
 //! An example of running two tasks concurrently. First task: blink an LED every
 //! second. Second task: loop back data over the serial interface.
 //!
-//! ```
+//! ```not_run
 //! extern crate embedded_hal as hal;
 //! extern crate futures;
 //!
@@ -379,7 +379,7 @@
 //!
 //! Same example as above but using `await!` instead of `futures`.
 //!
-//! ```
+//! ```not_run
 //! #![feature(generator_trait)]
 //! #![feature(generators)]
 //!
@@ -551,7 +551,7 @@
 //!
 //! - Asynchronous SPI transfer
 //!
-//! ```
+//! ```not_run
 //! #![feature(conservative_impl_trait)]
 //! #![feature(generators)]
 //! #![feature(generator_trait)]


### PR DESCRIPTION
Solve for issue #165.
Fix errors on build without `features` option. Mask tests with `nb` because it needs to rewrite.