### PR TITLE
Remove unsupported examples for hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ version = "0.2.3"
 version = "0.1.1"
 
 [dev-dependencies]
-stm32f3 = { version = "0.8", features = ["stm32f303", "rt"] }
 futures = "0.1.17"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 //!
 //! [`stm32f3`]: https://crates.io/crates/stm32f3
 //!
-//! ```
+//! ```not_run
 //! // crate: stm32f3xx-hal
 //! // An implementation of the `embedded-hal` traits for STM32F3xx microcontrollers
 //!


### PR DESCRIPTION
Remove stm32f3 hal implementation as dependency and it's examples from runned doc tests.
Following the #156 