### PR TITLE
Switch async code to use futures crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,12 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
 version = "0.2.3"
 
-[dependencies.nb]
-version = "0.1.1"
-
 [dev-dependencies]
 stm32f3 = { version = "0.8", features = ["stm32f303", "rt"] }
 futures = "0.1.17"
 
 [features]
-unproven = ["nb/unstable"]
+unproven = []
 
 [package.metadata.docs.rs]
 features = ["unproven"]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,7 +1,7 @@
 //! Analog-digital conversion traits
 
 #[cfg(feature = "unproven")]
-use nb;
+use core::task::Poll;
 
 /// A marker trait to identify MCU pins that can be used as inputs to an ADC channel.
 ///
@@ -61,6 +61,7 @@ pub trait Channel<ADC> {
 ///
 /// ```
 /// use embedded_hal::adc::{Channel, OneShot};
+/// use core::task::Poll::{self, Ready, Pending};
 ///
 /// struct MyAdc; // 10-bit ADC, with 5 channels
 /// # impl MyAdc {
@@ -76,12 +77,12 @@ pub trait Channel<ADC> {
 /// {
 ///    type Error = ();
 ///
-///    fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+///    fn read(&mut self, _pin: &mut PIN) -> Poll<Result<WORD, Self::Error>> {
 ///        let chan = 1 << PIN::channel();
 ///        self.power_up();
 ///        let result = self.do_conversion(chan);
 ///        self.power_down();
-///        Ok(result.into())
+///        Ready(Ok(result.into()))
 ///    }
 /// }
 /// ```
@@ -94,5 +95,5 @@ pub trait OneShot<ADC, Word, Pin: Channel<ADC>> {
     ///
     /// This method takes a `Pin` reference, as it is expected that the ADC will be able to sample
     /// whatever channel underlies the pin.
-    fn read(&mut self, pin: &mut Pin) -> nb::Result<Word, Self::Error>;
+    fn read(&mut self, pin: &mut Pin) -> Poll<Result<Word, Self::Error>>;
 }

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,7 +1,7 @@
 //! Random Number Generator Interface
 
 #[cfg(feature = "unproven")]
-use nb;
+use core::task::Poll;
 
 /// Nonblocking stream of random bytes.
 #[cfg(feature = "unproven")]
@@ -13,5 +13,5 @@ pub trait Read {
     type Error;
 
     /// Get a number of bytes from the RNG.
-    fn read(&mut self, buf: &mut [u8]) -> nb::Result<usize, Self::Error>;
+    fn read(&mut self, buf: &mut [u8]) -> Poll<Result<usize, Self::Error>>;
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,6 +1,6 @@
 //! Serial interface
 
-use nb;
+use core::task::Poll;
 
 /// Read half of a serial interface
 ///
@@ -11,7 +11,7 @@ pub trait Read<Word> {
     type Error;
 
     /// Reads a single word from the serial interface
-    fn read(&mut self) -> nb::Result<Word, Self::Error>;
+    fn read(&mut self) -> Poll<Result<Word, Self::Error>>;
 }
 
 /// Write half of a serial interface
@@ -20,8 +20,8 @@ pub trait Write<Word> {
     type Error;
 
     /// Writes a single word to the serial interface
-    fn write(&mut self, word: Word) -> nb::Result<(), Self::Error>;
+    fn write(&mut self, word: Word) -> Poll<Result<(), Self::Error>>;
 
     /// Ensures that none of the previously written words are still buffered
-    fn flush(&mut self) -> nb::Result<(), Self::Error>;
+    fn flush(&mut self) -> Poll<Result<(), Self::Error>>;
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,6 +1,6 @@
 //! Serial Peripheral Interface
 
-use nb;
+use core::task::Poll;
 
 /// Full duplex (master mode)
 ///
@@ -20,10 +20,10 @@ pub trait FullDuplex<Word> {
     ///
     /// **NOTE** A word must be sent to the slave before attempting to call this
     /// method.
-    fn read(&mut self) -> nb::Result<Word, Self::Error>;
+    fn read(&mut self) -> Poll<Result<Word, Self::Error>>;
 
     /// Sends a word to the slave
-    fn send(&mut self, word: Word) -> nb::Result<(), Self::Error>;
+    fn send(&mut self, word: Word) -> Poll<Result<(), Self::Error>>;
 }
 
 /// Clock polarity

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,7 +1,7 @@
 //! Timers
 
 use core::convert::Infallible;
-use nb;
+use core::task::Poll;
 
 /// A count down timer
 ///
@@ -18,11 +18,10 @@ use nb;
 /// You can use this timer to create delays
 ///
 /// ```
-/// extern crate embedded_hal as hal;
-/// #[macro_use(block)]
-/// extern crate nb;
+/// use embedded_hal as hal;
+/// use core::task::Poll::{self, Ready, Pending};
 ///
-/// use hal::prelude::*;
+/// use hal::{block, prelude::*};
 ///
 /// fn main() {
 ///     let mut led: Led = {
@@ -53,7 +52,7 @@ use nb;
 /// # impl hal::timer::CountDown for Timer6 {
 /// #     type Time = Seconds;
 /// #     fn start<T>(&mut self, _: T) where T: Into<Seconds> {}
-/// #     fn wait(&mut self) -> ::nb::Result<(), Infallible> { Ok(()) }
+/// #     fn wait(&mut self) -> Poll<Result<(), Infallible>> { Ready(Ok(())) }
 /// # }
 /// ```
 pub trait CountDown {
@@ -73,7 +72,7 @@ pub trait CountDown {
     /// finishes.
     /// - Otherwise the behavior of calling `wait` after the last call returned `Ok` is UNSPECIFIED.
     /// Implementers are suggested to panic on this scenario to signal a programmer error.
-    fn wait(&mut self) -> nb::Result<(), Infallible>;
+    fn wait(&mut self) -> Poll<Result<(), Infallible>>;
 }
 
 /// Marker trait that indicates that a timer is periodic


### PR DESCRIPTION
Remove using `nb` crate for asynchronously run code - use `core::futures` for replace it.
RFC for these changes is #172 