### PR TITLE
Add CapturePin trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -795,6 +795,26 @@ pub trait Capture {
         R: Into<Self::Time>;
 }
 
+/// A single input capture channel / pin
+///
+/// See `Capture` for details
+#[cfg(feature = "unproven")]
+pub trait CapturePin {
+    /// Type  of value returned by capture
+    type Capture;
+    /// Enumeration of `Capture` errors
+    ///
+    /// Possible errors:
+    ///
+    /// - *overcapture*, the previous capture value was overwritten because it
+    ///   was not read in a timely manner
+    type Error;
+
+    /// "Waits" for a transition in the capture `channel` and returns the value
+    /// of counter at that instant
+    fn capture(&mut self) -> nb::Result<Self::Capture, Self::Error>;
+}
+
 /// Pulse Width Modulation
 ///
 /// *This trait is available if embedded-hal is built with the `"unproven"` feature.*


### PR DESCRIPTION
The `CapturePin` trait is the input capture analogue to the `PwmPin` trait, representing a single capture channel. Unlike `PwmPin`, there's no `enable` or `disable` methods, because some chips, such as the MSP430FR2355, may have trouble implementing those two methods on capture abstractions. The proposed trait has been implemented in [msp430fr2x5x-hal](https://github.com/YuhanLiin/msp430fr2x5x-hal/blob/master/src/capture.rs#L300).