### PR TITLE
Release 0.2.4 semver-trick for embedded-hal v0.3.x release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,14 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "0.2.3"
+version = "0.2.4"
 
 [dependencies.nb]
-version = "0.1.1"
+version = "0.1.2"
+
+[dependencies.embedded-hal-v3]
+package = "embedded-hal"
+version = "0.3.0"
 
 [dev-dependencies]
 stm32f3 = { version = "0.8", features = ["stm32f303", "rt"] }
@@ -26,3 +30,7 @@ unproven = ["nb/unstable"]
 
 [package.metadata.docs.rs]
 features = ["unproven"]
+
+# TODO: remove before publishing
+[patch.crates-io]
+embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "release-0.3.0" }

--- a/src/digital/mod.rs
+++ b/src/digital/mod.rs
@@ -3,24 +3,8 @@
 //!
 //!
 
-// Deprecated / infallible traits
-#[deprecated(
-    since = "0.2.2",
-    note = "Deprecated because the methods cannot return errors. \
-            Users should use the traits in digital::v2."
-)]
-pub mod v1;
-
-// New / fallible traits
-pub mod v2;
-
-// v2 -> v1 compatibility wrappers
-// These require explicit casts from v2 -> v1
-pub mod v1_compat;
-
-// v1 -> v2 compatibility shims
-// These are implicit over v1 implementations
-pub mod v2_compat;
+#[allow(deprecated)]
+pub use embedded_hal_v3::digital::{v1, v2, v1_compat, v2_compat};
 
 // Re-export old traits so this isn't a breaking change
 #[allow(deprecated)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -688,16 +688,21 @@
 #[macro_use]
 extern crate nb;
 
-pub mod adc;
-pub mod blocking;
+extern crate embedded_hal_v3;
+
+pub use embedded_hal_v3::{
+    adc,
+    blocking,
+    fmt,
+    prelude,
+    rng,
+    serial,
+    spi,
+    timer,
+    watchdog,
+};
+
 pub mod digital;
-pub mod fmt;
-pub mod prelude;
-pub mod rng;
-pub mod serial;
-pub mod spi;
-pub mod timer;
-pub mod watchdog;
 
 /// Input capture
 ///


### PR DESCRIPTION
- bump cargo version
- semver trick against embedded-hal v0.3.x