### PR TITLE
Add methods to enable/disable the entire timer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -862,11 +862,17 @@ pub trait Pwm {
     /// (e.g. `0.0 .. 1.0`) or an integer representation (e.g. `0 .. 65535`)
     type Duty;
 
+    /// Disables a PWM timer (all channels)
+    fn disable(&mut self);
+
+    /// Enables a PWM timer (all channels)
+    fn enable(&mut self);
+
     /// Disables a PWM `channel`
-    fn disable(&mut self, channel: Self::Channel);
+    fn channel_disable(&mut self, channel: Self::Channel);
 
     /// Enables a PWM `channel`
-    fn enable(&mut self, channel: Self::Channel);
+    fn channel_enable(&mut self, channel: Self::Channel);
 
     /// Returns the current PWM period
     fn get_period(&self) -> Self::Time;


### PR DESCRIPTION
I am submitting this simple PR to start discussion on the recently opened issue #182.  I have simply renamed the existing `enable` and `disable` methods to be `channel_enable` and `channel_disable`.  I have also added two new methods, `enable`/`disable`, which would then be expected to be used to enable/disable the entire timer.

I think that this functionality is useful so that one does not need to temporarily store the current duty for each channel in order to "disable" the timer.  The state would be maintained and it results in a single read/write to the timer control registers.