### PR TITLE
InputPin instead of OutputPin for compatibility shim

### DIFF
--- a/src/digital/v1_compat.rs
+++ b/src/digital/v1_compat.rs
@@ -113,7 +113,7 @@ pub struct OldInputPin<T> {
 
 impl<T, E> OldInputPin<T>
 where
-    T: v2::OutputPin<Error = E>,
+    T: v2::InputPin<Error = E>,
     E: core::fmt::Debug,
 {
     /// Create an `OldInputPin` wrapper around a `v2::InputPin`.


### PR DESCRIPTION
The OldInputPin required OutputPin instead of InputPin for the new impl. Fix the trait bound.