### PR TITLE
Add MSRV configuration to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ matrix:
       rust: nightly
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
+    # Minimum supported Rust version
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: 1.35.0
+      if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
+
 before_install: set -e
 
 install:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ list.
 
 [awesome-embedded-rust]: https://github.com/rust-embedded/awesome-embedded-rust#driver-crates
 
+# Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.35 and up. It *might*
+compile with older versions but that may change in any new patch release.
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
The compatibility with the MSRV should be checked by the CI. At the moment that is Rust 1.35.0 due to [this issue](https://github.com/rust-lang/rust/issues/54973).
The MSRV and its update process should probably also be documented in the README.