### PR TITLE
InputPin instead of OutputPin for compatibility shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Fix the compatibility shim, where InputPin was implemented only for inner v1::OutputPin
+  values, a potentially serious problem.
 
 ## [v0.2.3] - 2019-05-09
 

--- a/src/digital/v1_compat.rs
+++ b/src/digital/v1_compat.rs
@@ -12,14 +12,14 @@ pub struct OldOutputPin<T> {
     pin: T,
 }
 
-impl <T, E> OldOutputPin<T>
+impl<T, E> OldOutputPin<T>
 where
-    T: v2::OutputPin<Error=E>,
+    T: v2::OutputPin<Error = E>,
     E: core::fmt::Debug,
 {
     /// Create a new OldOutputPin wrapper around a `v2::OutputPin`
     pub fn new(pin: T) -> Self {
-        Self{pin}
+        Self { pin }
     }
 
     /// Fetch a reference to the inner `v2::OutputPin` impl
@@ -29,22 +29,22 @@ where
     }
 }
 
-impl <T, E> From<T> for OldOutputPin<T>
+impl<T, E> From<T> for OldOutputPin<T>
 where
-    T: v2::OutputPin<Error=E>,
+    T: v2::OutputPin<Error = E>,
     E: core::fmt::Debug,
 {
     fn from(pin: T) -> Self {
-        OldOutputPin{pin}
+        OldOutputPin { pin }
     }
 }
 
 /// Implementation of `v1::OutputPin` trait for fallible `v2::OutputPin` output pins
 /// where errors will panic.
 #[allow(deprecated)]
-impl <T, E> v1::OutputPin for OldOutputPin<T>
+impl<T, E> v1::OutputPin for OldOutputPin<T>
 where
-    T: v2::OutputPin<Error=E>,
+    T: v2::OutputPin<Error = E>,
     E: core::fmt::Debug,
 {
     fn set_low(&mut self) {
@@ -60,9 +60,9 @@ where
 /// where errors will panic.
 #[cfg(feature = "unproven")]
 #[allow(deprecated)]
-impl <T, E> v1::StatefulOutputPin for OldOutputPin<T> 
+impl<T, E> v1::StatefulOutputPin for OldOutputPin<T>
 where
-    T: v2::StatefulOutputPin<Error=E>,
+    T: v2::StatefulOutputPin<Error = E>,
     E: core::fmt::Debug,
 {
     fn is_set_low(&self) -> bool {
@@ -82,26 +82,25 @@ pub struct OldInputPin<T> {
 }
 
 #[cfg(feature = "unproven")]
-impl <T, E> OldInputPin<T>
+impl<T, E> OldInputPin<T>
 where
-    T: v2::OutputPin<Error=E>,
+    T: v2::InputPin<Error = E>,
     E: core::fmt::Debug,
 {
     /// Create an `OldInputPin` wrapper around a `v2::InputPin`.
     pub fn new(pin: T) -> Self {
-        Self{pin}
+        Self { pin }
     }
-
 }
 
 #[cfg(feature = "unproven")]
-impl <T, E> From<T> for OldInputPin<T>
+impl<T, E> From<T> for OldInputPin<T>
 where
-    T: v2::InputPin<Error=E>,
+    T: v2::InputPin<Error = E>,
     E: core::fmt::Debug,
 {
     fn from(pin: T) -> Self {
-        OldInputPin{pin}
+        OldInputPin { pin }
     }
 }
 
@@ -109,9 +108,9 @@ where
 /// where errors will panic.
 #[cfg(feature = "unproven")]
 #[allow(deprecated)]
-impl <T, E> v1::InputPin for OldInputPin<T>
+impl<T, E> v1::InputPin for OldInputPin<T>
 where
-    T: v2::InputPin<Error=E>,
+    T: v2::InputPin<Error = E>,
     E: core::fmt::Debug,
 {
     fn is_low(&self) -> bool {
@@ -137,7 +136,7 @@ mod tests {
     #[derive(Clone)]
     struct NewOutputPinImpl {
         state: bool,
-        res: Result<(), ()>
+        res: Result<(), ()>,
     }
 
     impl v2::OutputPin for NewOutputPinImpl {
@@ -147,7 +146,7 @@ mod tests {
             self.state = false;
             self.res
         }
-        fn set_high(&mut self) -> Result<(), Self::Error>{
+        fn set_high(&mut self) -> Result<(), Self::Error> {
             self.state = true;
             self.res
         }
@@ -159,35 +158,47 @@ mod tests {
     }
 
     #[allow(deprecated)]
-    impl <T>OldOutputPinConsumer<T> 
-    where T: v1::OutputPin 
+    impl<T> OldOutputPinConsumer<T>
+    where
+        T: v1::OutputPin,
     {
         pub fn new(pin: T) -> OldOutputPinConsumer<T> {
-            OldOutputPinConsumer{ _pin: pin }
+            OldOutputPinConsumer { _pin: pin }
         }
     }
 
     #[test]
     fn v1_v2_output_explicit() {
-        let i = NewOutputPinImpl{state: false, res: Ok(())};
+        let i = NewOutputPinImpl {
+            state: false,
+            res: Ok(()),
+        };
         let _c: OldOutputPinConsumer<OldOutputPin<_>> = OldOutputPinConsumer::new(i.into());
     }
 
     #[test]
     fn v1_v2_output_state() {
-        let mut o: OldOutputPin<_> = NewOutputPinImpl{state: false, res: Ok(())}.into();
+        let mut o: OldOutputPin<_> = NewOutputPinImpl {
+            state: false,
+            res: Ok(()),
+        }
+        .into();
 
         o.set_high();
         assert_eq!(o.inner().state, true);
 
         o.set_low();
-        assert_eq!(o.inner().state, false);   
+        assert_eq!(o.inner().state, false);
     }
 
     #[test]
     #[should_panic]
     fn v1_v2_output_panic() {
-        let mut o: OldOutputPin<_> = NewOutputPinImpl{state: false, res: Err(())}.into();
+        let mut o: OldOutputPin<_> = NewOutputPinImpl {
+            state: false,
+            res: Err(()),
+        }
+        .into();
 
         o.set_high();
     }
@@ -207,7 +218,7 @@ mod tests {
         fn is_low(&self) -> Result<bool, Self::Error> {
             self.state.map(|v| v == false)
         }
-        fn is_high(&self) -> Result<bool, Self::Error>{
+        fn is_high(&self) -> Result<bool, Self::Error> {
             self.state.map(|v| v == true)
         }
     }
@@ -220,25 +231,26 @@ mod tests {
 
     #[cfg(feature = "unproven")]
     #[allow(deprecated)]
-    impl <T>OldInputPinConsumer<T> 
-    where T: v1::InputPin 
+    impl<T> OldInputPinConsumer<T>
+    where
+        T: v1::InputPin,
     {
         pub fn new(pin: T) -> OldInputPinConsumer<T> {
-            OldInputPinConsumer{ _pin: pin }
+            OldInputPinConsumer { _pin: pin }
         }
     }
 
     #[cfg(feature = "unproven")]
     #[test]
     fn v1_v2_input_explicit() {
-        let i = NewInputPinImpl{state: Ok(false)};
+        let i = NewInputPinImpl { state: Ok(false) };
         let _c: OldInputPinConsumer<OldInputPin<_>> = OldInputPinConsumer::new(i.into());
     }
 
     #[cfg(feature = "unproven")]
     #[test]
     fn v1_v2_input_state() {
-        let i:  OldInputPin<_> = NewInputPinImpl{state: Ok(false)}.into();
+        let i: OldInputPin<_> = NewInputPinImpl { state: Ok(false) }.into();
 
         assert_eq!(i.is_low(), true);
         assert_eq!(i.is_high(), false);
@@ -248,9 +260,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn v1_v2_input_panic() {
-        let i:  OldInputPin<_> = NewInputPinImpl{state: Err(())}.into();
+        let i: OldInputPin<_> = NewInputPinImpl { state: Err(()) }.into();
 
         i.is_low();
     }
-
 }


### PR DESCRIPTION
The OldInputPin required OutputPin instead of InputPin for the new impl. Fix the trait bound.