### PR TITLE
[Proposal] I2S traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- I2S (Inter-IC Sound) traits.
 
 ### Changed
 

--- a/src/blocking/i2s.rs
+++ b/src/blocking/i2s.rs
@@ -1,0 +1,39 @@
+//! Blocking I2S API
+
+/// Blocking read
+pub trait Read<W> {
+    /// Error type
+    type Error;
+
+    /// Reads enough bytes from the slave to fill `left_words` and `right_words`.
+    fn try_read<'w>(
+        &mut self,
+        left_words: &'w mut [W],
+        right_words: &'w mut [W],
+    ) -> Result<(), Self::Error>;
+}
+
+/// Blocking write
+pub trait Write<W> {
+    /// Error type
+    type Error;
+
+    /// Sends `left_words` and `right_words` to the slave.
+    fn try_write<'w>(
+        &mut self,
+        left_words: &'w [W],
+        right_words: &'w [W],
+    ) -> Result<(), Self::Error>;
+}
+
+/// Blocking write (iterator version)
+pub trait WriteIter<W> {
+    /// Error type
+    type Error;
+
+    /// Sends `left_words` and `right_words` to the slave.
+    fn try_write<LW, RW>(&mut self, left_words: LW, right_words: RW) -> Result<(), Self::Error>
+    where
+        LW: IntoIterator<Item = W>,
+        RW: IntoIterator<Item = W>;
+}

--- a/src/blocking/i2s.rs
+++ b/src/blocking/i2s.rs
@@ -32,7 +32,11 @@ pub trait WriteIter<W> {
     type Error;
 
     /// Sends `left_words` and `right_words` to the slave.
-    fn try_write<LW, RW>(&mut self, left_words: LW, right_words: RW) -> Result<(), Self::Error>
+    fn try_write_iter<LW, RW>(
+        &mut self,
+        left_words: LW,
+        right_words: RW,
+    ) -> Result<(), Self::Error>
     where
         LW: IntoIterator<Item = W>,
         RW: IntoIterator<Item = W>;

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod delay;
 pub mod i2c;
+pub mod i2s;
 pub mod rng;
 pub mod serial;
 pub mod spi;

--- a/src/i2s.rs
+++ b/src/i2s.rs
@@ -1,0 +1,17 @@
+//! I2S - Inter-IC Sound Interface
+
+use nb;
+
+/// Full duplex
+pub trait FullDuplex<Word> {
+    /// Error type
+    type Error;
+
+    /// Reads the left word and right word available.
+    ///
+    /// The order is in the result is `(left_word, right_word)`
+    fn try_read(&mut self) -> nb::Result<(Word, Word), Self::Error>;
+
+    /// Sends a left word and a right word to the slave.
+    fn try_send(&mut self, left_word: Word, right_word: Word) -> nb::Result<(), Self::Error>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,6 +412,7 @@ pub mod blocking;
 pub mod capture;
 pub mod digital;
 pub mod fmt;
+pub mod i2s;
 pub mod prelude;
 pub mod pwm;
 pub mod qei;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -28,6 +28,7 @@ pub use crate::digital::InputPin as _embedded_hal_digital_InputPin;
 pub use crate::digital::OutputPin as _embedded_hal_digital_OutputPin;
 pub use crate::digital::StatefulOutputPin as _embedded_hal_digital_StatefulOutputPin;
 pub use crate::digital::ToggleableOutputPin as _embedded_hal_digital_ToggleableOutputPin;
+pub use crate::i2s::FullDuplex as _embedded_hal_i2s_FullDuplex;
 pub use crate::pwm::Pwm as _embedded_hal_Pwm;
 pub use crate::pwm::PwmPin as _embedded_hal_PwmPin;
 pub use crate::qei::Qei as _embedded_hal_Qei;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,6 +14,9 @@ pub use crate::blocking::i2c::{
     WriteIterRead as _embedded_hal_blocking_i2c_WriteIterRead,
     WriteRead as _embedded_hal_blocking_i2c_WriteRead,
 };
+pub use crate::blocking::i2s::{
+    Read as _embedded_hal_blocking_i2s_Read, Write as _embedded_hal_blocking_i2s_Write,
+};
 pub use crate::blocking::rng::Read as _embedded_hal_blocking_rng_Read;
 pub use crate::blocking::serial::Write as _embedded_hal_blocking_serial_Write;
 pub use crate::blocking::spi::{


### PR DESCRIPTION
I added some I2S traits to kick off the discussion started in #203.
The traits accept two words for left and right and are otherwise similar to SPI.

An interleaved version can be found in the [`i2s-interleaved`](https://github.com/eldruin/embedded-hal/tree/i2s-interleaved) branch. The data should be passed interleaved. e.g. `[left0,right0,left1,right1,...]`

A version of these traits for the embedded-hal 0.2.x version can be found in the [`i2s-v0.2.x`](https://github.com/eldruin/embedded-hal/tree/i2s-v0.2.x) branch.

There is another MCU implementation in [`stm32f4xx-hal`](https://github.com/stm32-rs/stm32f4xx-hal/pull/265)

TODO:
- [X] Demo microcontroller HAL implementation:
    - [X] [stm32h7xx-hal](https://github.com/stm32-rs/stm32h7xx-hal/pull/99) - [discussion issue](https://github.com/stm32-rs/stm32h7xx-hal/issues/90)
    - [ ] [[WIP] stm32f4xx-hal](https://github.com/stm32-rs/stm32f4xx-hal/pull/145)
- [x] [Bit-banging HAL implementation supporting 16-bit and 32-bit packets](https://github.com/eldruin/bitbang-hal/blob/i2s-v0.2.x/src/i2s.rs)
    - [x] [Working example tested using both MAX98357A and PCM5102A](https://github.com/eldruin/driver-examples/blob/i2s-bitbang-bp/stm32f1-bluepill/examples/i2s-audio-bitbang.rs)
- [X] [Working example of saw wave](https://github.com/maxekman/stm32f407g-disc/blob/dac-support-with-cs43l22/examples/audio.rs)
    - Uses driver: https://github.com/maxekman/cs43l22
- [X] Full-duplex trait implementation
    - [X] [stm32h7xx-hal](https://github.com/stm32-rs/stm32h7xx-hal/pull/99) - [discussion issue](https://github.com/stm32-rs/stm32h7xx-hal/issues/90)
- [x] Changelog entry.
- [ ] Remove `try_` prefix
- [ ] Move files according to #278 after that is merged

Thoughts?
cc. @maxekman