### PR TITLE
Proposal for Configure baudrate trait

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -25,3 +25,13 @@ pub trait Write<Word> {
     /// Ensures that none of the previously written words are still buffered
     fn try_flush(&mut self) -> nb::Result<(), Self::Error>;
 }
+
+/// Enable changing the baudrate after initiation of serial interface
+pub trait ConfigureBaud {
+    /// Baudrate type
+    type BaudRate;
+    /// Set baud error
+    type Error;
+    /// Change baudrate
+    fn set_baudrate(&mut self, baudrate: Self::BaudRate) -> Result<(), Self::Error>;
+}


### PR DESCRIPTION
This trait lets the implementer choose the type for `Baudrate` as this is done in different ways in different crates.
Returning a result lets the implementer sort out bad, incompatible or impossible bauds, or simply return an unsupported error.
An implementation can be seen at [stm32l4xx-hal/feature/change-baud/](https://github.com/MathiasKoch/stm32l4xx-hal/blob/feature/change-baud/src/serial.rs#L814)
In this implementation the clock freq is saved with the `Uart` struct, and the used to change the baud. If the clock frequency were to change the Uart would have to be reinitialized anyway.