### PR TITLE
[0.2.x]: Fix warning, remove #[deny(warnings)] but keep check on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: rust
 
+env:
+  global:
+    RUSTFLAGS='-D warnings'
+
 matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ version = "1.0.2"
 version = "0.1.1"
 
 [dev-dependencies]
-stm32f30x = "0.6.0"
+stm32f30x = "0.8.0"
 futures = "0.1.17"
 
 [features]

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -3,7 +3,7 @@
 //! TODO write example of usage
 use core::fmt::{Result, Write};
 
-impl<Word, Error> Write for ::serial::Write<Word, Error=Error>
+impl<Word, Error> Write for dyn (::serial::Write<Word, Error=Error>)
 where
     Word: From<u8>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,7 +683,6 @@
 //! ```
 
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![no_std]
 
 #[macro_use]


### PR DESCRIPTION
This fixes #213. Additionally I removed #[deny(warnings)] but added a check for it on CI.
I think we should cherry pick #138 to the 0.2.x branch as well and release a 0.2.4 version, since 1.0 will still take a while.
I can do that in a separate PR.