### PR TITLE
Restrict ADC ID type to Copy types

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -40,7 +40,7 @@ pub trait Channel<ADC> {
     /// A type used to identify this ADC channel. For example, if the ADC has eight channels, this
     /// might be a `u8`. If the ADC has multiple banks of channels, it could be a tuple, like
     /// `(u8: bank_id, u8: channel_id)`.
-    type ID;
+    type ID: Copy;
 
     /// Get the specific ID that identifies this channel, for example `0_u8` for the first ADC
     /// channel, if Self::ID is u8.


### PR DESCRIPTION
This fixes a deny-by-default clippy lint:

```
error: a `const` item should never be interior mutable
  --> src/adc.rs:47:5
   |
47 |     const CHANNEL: Self::ID;
   |     ^^^^^^^^^^^^^^^--------^
   |                    |
   |                    consider requiring `<Self as adc::Channel<ADC>>::ID` to be `Copy`
   |
   = note: `#[deny(clippy::declare_interior_mutable_const)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#declare_interior_mutable_const
```

Signed-off-by: Daniel Egger <daniel@eggers-club.de>