### PR TITLE
PwmPin: allow get_duty to return the old value for some time

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -114,6 +114,9 @@ pub trait PwmPin {
     fn try_enable(&mut self) -> Result<(), Self::Error>;
 
     /// Returns the current duty cycle
+    ///
+    /// While the pin is transitioning to the new duty cycle after a `try_set_duty` call, this may
+    /// return the old or the new duty cycle depending on the implementation.
     fn try_get_duty(&self) -> Result<Self::Duty, Self::Error>;
 
     /// Returns the maximum duty cycle value


### PR DESCRIPTION
This is #140 rebased to master.
However, I suppose the same thing applies to the `Pwm::try_get_duty()` method. Shouldn't the same note be added to that method as well?

Closes #140