### PR TITLE
 Pwm: allow get_duty to return the old value for some time

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -79,6 +79,9 @@ pub trait Pwm {
     fn try_get_period(&self) -> Result<Self::Time, Self::Error>;
 
     /// Returns the current duty cycle
+    ///
+    /// While the pin is transitioning to the new duty cycle after a `try_set_duty` call, this may
+    /// return the old or the new duty cycle depending on the implementation.
     fn try_get_duty(&self, channel: Self::Channel) -> Result<Self::Duty, Self::Error>;
 
     /// Returns the maximum duty cycle value


### PR DESCRIPTION
This is #140 applied to the `Pwm` trait as well, since the same concerns apply. Follows up on #236.