### PR TITLE
blocking DAC trait

### DIFF
--- a/src/blocking/dac.rs
+++ b/src/blocking/dac.rs
@@ -1,0 +1,10 @@
+//! Trait for digital to analog conversion
+
+/// Represents a single DAC channel.
+pub trait DAC<WORD> {
+    /// Error type returned by DAC methods
+    type Error;
+
+    /// Set the output of the DAC
+    fn try_set_output(&mut self, value: WORD) -> Result<(), Self::Error>;
+}

--- a/src/blocking/dac.rs
+++ b/src/blocking/dac.rs
@@ -1,6 +1,10 @@
-//! Trait for digital to analog conversion
+//! Blocking DAC trait for single channel digital to analog conversion
 
-/// Represents a single DAC channel.
+/// A single DAC channel. Word is the type used to represent a single sample, this would typically
+/// be u8, u16 or u32.
+/// Note that not all bits will always be used. A 12 bit DAC for example will probably use u16 here
+/// <DISCUSSION> should we prescribe to use the most significant bits here for compat between word
+///   sizes?
 pub trait DAC<WORD> {
     /// Error type returned by DAC methods
     type Error;

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -4,6 +4,7 @@
 //! traits. To save boilerplate when that's the case a `Default` marker trait may be provided.
 //! Implementing that marker trait will opt in your type into a blanket implementation.
 
+pub mod dac;
 pub mod delay;
 pub mod i2c;
 pub mod rng;


### PR DESCRIPTION
After some discussion on the rust embedded matrix chat during the Oxidize impl days I made a very simple implementation for a blocking DAC trait. This is a blocking implementation to make it usable for implementing in peripherals that use busses that do not have an nb interface like I2C.

I created a sample implementation for the Microchip mcp4725 I2C DAC here; https://github.com/mendelt/mcp4725/blob/dac-hal/src/lib.rs

The trait only supports setting the output of a single DAC channel. I'm planning on trying this out for the AD5668 8 channel DAC using a .split method that returns a channel instance for each of the 8 channels next.

Some discussion. We might want to have prescribed behavior for DACs that use less than the full word-length. The mcp4725 for example uses 12 of the 16 bits. Right now it uses the least significant bits but I'm thinking about fixing this and using the 12 most significant bits. I think this might make more sense in terms of the abstraction the trait provides. Programs using this trait would get more logical behavior when replacing a 16 bit DAC with a 14 or 12 bit one.