### PR TITLE
Storage Traits for on and off board storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - 10-bit addressing mode for I2C traits.
+- Storage traits for on and off board devices
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -698,6 +698,7 @@ pub mod qei;
 pub mod rng;
 pub mod serial;
 pub mod spi;
+pub mod storage;
 pub mod timer;
 pub mod watchdog;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,6 @@
 //! Storage
-//! The Read and Write traits are seperate to allow for Read Only Memory as well as Read and Write
-//! Example implementations include:
+/// The Read and Write traits are seperate to allow for Read Only Memory as well as Read and Write
+/// Example implementations include:
 
 use nb;
 
@@ -12,7 +12,7 @@ pub struct AddressOffset<U>(U);
 use core::ops::Add;
 
 /// Implement add for the Address and AddressOffset Types
-impl Add for Address<U> {
+impl<U> Add<AddressOffset<U>> for Address<U> {
     type Output = Self;
 
     fn add(self, other: AddressOffset<U>) -> Self {
@@ -96,9 +96,15 @@ pub trait ErasePage<U> {
     /// Erase the page of memory
     /// For flash devices, this sets the whole page to 0xFF
     /// Implementations should mask the address as required to get the page to erase
-    fn try_erase(&mut self, page: Page<U>) -> nb::Result<(), Self::Error>;
+    fn try_erase_page(&mut self, page: Page<U>) -> nb::Result<(), Self::Error>;
+
+    /// Erase the page of memory at the address. Note: The only valid address is the start of the page
+    /// For flash devices, this sets the whole page to 0xFF
+    /// Implementations should mask the address as required to get the page to erase
+    fn try_erase_address(&mut self, address: Address<U>) -> nb::Result<(), Self::Error>;
 }
 
+/// This trait allows for checking that data can fit before writing to the device. As some devices have limits on writing accross pages, the page size is also included
  pub trait StorageSize<Word,U> {
     /// An enumeration of Storage errors
     type Error;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,79 @@
+//! Storage
+//! The Read and Write traits are seperate to allow for Read Only Memory as well as Read and Write
+//! Example implementations include:
+
+use nb;
+
+/// Read a single word from the device
+/// `Word` type allows any word size to be used
+pub trait SingleRead<Word> {
+    /// An enumeration of Storage errors
+    type Error;
+
+    /// Reads the word stored at the address
+    /// ```
+    /// pub fn try_read(&mut self, address: usize) -> nb::Result<u8, Self::Error>
+    ///     let address = address as *const _;
+    ///     unsafe {
+    ///         Ok(core::slice::from_raw_parts::<'static, u8>(address,length)) 
+    ///     }
+    /// ```
+    fn try_read(&mut self, address: usize) -> nb::Result<Word, Self::Error>;
+
+}
+
+/// Write a single word to the device
+/// `Word` type allows any word size to be used
+pub trait SingleWrite<Word> {
+    /// An enumeration of Storage errors
+    type Error;
+
+    /// Writes the word to the address
+    fn try_write(&mut self, address: usize, word: Word) -> nb::Result<(), Self::Error>;
+
+}
+
+/// Read multiple bytes from the device
+/// Intended to be used for when there is a optimized method of reading multiple bytes
+/// 
+/// Iterating over the slice is a valid method to ```impl``` this trait
+pub trait MultiRead<Word> {
+    /// An enumeration of Storage errors
+    type Error;
+
+    /// Reads the words stored at the address to fill the buffer
+    /// ```
+    /// pub fn try_read_slice(&mut self, address: usize,  buf: &mut [Word]) -> nb::Result<Word, Self::Error>
+    ///     let address = address as *const _;
+    ///     unsafe {
+    ///         buf = core::slice::from_raw_parts::<'static, Word>(address,buf.len())
+    ///     }
+    ///     
+    ///     Ok() 
+    /// }
+    /// ```
+    fn try_read_slice(&mut self, address: usize, buf: &mut [Word]) -> nb::Result<(), Self::Error>;
+}
+
+/// Write multiple bytes to the device
+/// Intended to be used for when there is a optimized method of reading multiple bytes
+/// 
+/// Iterating over the slice is a valid method to ```impl``` this trait
+pub trait MultiWrite<Word> {
+    /// An enumeration of Storage errors
+    type Error;
+
+    /// Writes the buffer to the address
+    fn try_write_slice(&mut self, address: usize, buf: &[Word]) -> nb::Result<(), Self::Error>;
+}
+
+/// For Flash storage, the write functions can't set a bit to 1. To enable a complete rewrite flash, it needs to be cleared beforehand
+/// For non flash devices, this trait is not required, but it can be used to clear data as recommended by the device
+pub trait ClearPage<Word> {
+    /// An enumeration of Storage errors
+    type Error;
+
+    /// Clear the page of memory at the address
+    /// For flash devices, this sets the whole page to 0xFF
+    fn try_clear(&mut self, address: usize) -> nb::Result<(), Self::Error>;
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -35,7 +35,7 @@ pub trait SingleRead<Word,U> {
     /// Reads the word stored at the address
     /// ```
     /// pub fn try_read(&mut self, address: Address) -> nb::Result<u8, Self::Error>
-    ///     let address = address as *const _;
+    ///     let address = address.0 as *const _;
     ///     unsafe {
     ///         Ok(core::slice::from_raw_parts::<'static, u8>(address,length)) 
     ///     }
@@ -68,7 +68,7 @@ pub trait MultiRead<Word,U> {
     /// Reads the words stored at the address to fill the buffer
     /// ```
     /// pub fn try_read_slice(&mut self, address: Address,  buf: &mut [Word]) -> nb::Result<Word, Self::Error>
-    ///     let address = address as *const _;
+    ///     let address = address.0 as *const _;
     ///     unsafe {
     ///         buf = core::slice::from_raw_parts::<'static, Word>(address,buf.len())
     ///     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -6,9 +6,9 @@
 use nb;
 
 /// Address represents an unsigned int. This allows for devices that have bigger or smaller address spaces than the host.
-pub struct Address<U>(U);
+pub struct Address<U>(pub U);
 /// Address Offset represents an unsigned int that is used as an optional offset from the base address.
-pub struct AddressOffset<U>(U);
+pub struct AddressOffset<U>(pub U);
 
 use core::ops::Add;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,7 +8,7 @@ pub struct Address<U>(pub U);
 /// Address Offset represents an unsigned integer that is used as an optional offset from the base address.
 pub struct AddressOffset<U>(pub U);
 
-use core::ops::{Add,Sub};
+use core::ops::{Add, Sub};
 
 /// Implement add for the Address and AddressOffset Types.
 impl<'a, 'b, U> Add<&'b AddressOffset<U>> for &'a Address<U>
@@ -106,8 +106,9 @@ pub trait MultiWrite<Word, U> {
     /// An enumeration of Storage errors
     type Error;
 
-    /// Writes the buffer to the address
-    fn try_write_slice(&mut self, address: Address<U>, buf: &[Word])
+    /// Writes the buffer to the address.
+    // Impls using spi will need a mutable buffer
+    fn try_write_slice(&mut self, address: Address<U>, buf: &mut [Word])
         -> nb::Result<(), Self::Error>;
 }
 
@@ -137,12 +138,11 @@ pub trait StorageSize<Word, U> {
     /// Returns the start address of the device
     fn try_start_address(&mut self) -> nb::Result<Address<U>, Self::Error>;
 
-    /// Returns the maximum size that can be stored by the device
+    /// Returns the maximum number of words that can be stored by the device
     fn try_total_size(&mut self) -> nb::Result<AddressOffset<U>, Self::Error>;
 
-    /// For devices that are paged, this should return the size of the page
+    /// For devices that are paged, this should return the number of words of the page
     ///
     /// For non paged devices, this should return the AddressOffset in ```try_total_size```
     fn try_page_size(&mut self) -> nb::Result<AddressOffset<U>, Self::Error>;
-
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -108,8 +108,11 @@ pub trait MultiWrite<Word, U> {
 
     /// Writes the buffer to the address.
     // Impls using spi will need a mutable buffer
-    fn try_write_slice(&mut self, address: Address<U>, buf: &mut [Word])
-        -> nb::Result<(), Self::Error>;
+    fn try_write_slice(
+        &mut self,
+        address: Address<U>,
+        buf: &mut [Word],
+    ) -> nb::Result<(), Self::Error>;
 }
 
 /// A common interface to erase pages or memory locations.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -86,7 +86,7 @@ pub trait MultiWrite<Word,U> {
 
 /// For Flash storage, the write functions can't set a bit to 1. To enable a complete rewrite flash, it needs to be erased beforehand
 /// For non flash devices, this trait is not required, but it can be used to erase data as recommended by the device (EG set all fields to 0)
-pub trait ErasePage<Word,U> {
+pub trait ErasePage<U> {
     /// An enumeration of Storage errors
     type Error;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,8 +1,6 @@
 //! Storage
 /// Traits to allow on and off board storage deivces to read and write data
 /// Allows for Read Only Memory as well as Read and Write Memory
-
-
 use nb;
 
 /// Address represents an unsigned int. This allows for devices that have bigger or smaller address spaces than the host.
@@ -13,13 +11,15 @@ pub struct AddressOffset<U>(pub U);
 use core::ops::Add;
 
 /// Implement add for the Address and AddressOffset Types.
-impl<'a, 'b, U> Add<&'b AddressOffset<U>> for &'a Address<U> where U: Add<U, Output=U> + Copy {
+impl<'a, 'b, U> Add<&'b AddressOffset<U>> for &'a Address<U>
+where
+    U: Add<U, Output = U> + Copy,
+{
     type Output = Address<U>;
 
     fn add(self, other: &'b AddressOffset<U>) -> Address<U> {
         Address(self.0 + other.0)
     }
-
 }
 
 /// Page represents an unsigned int that is a Page ID in the device memory space.
@@ -28,7 +28,7 @@ pub struct Page<U>(U);
 /// Read a single word from the device.
 ///
 /// `Word` type allows any word size to be used.
-pub trait SingleRead<Word,U> {
+pub trait SingleRead<Word, U> {
     /// An enumeration of Storage errors
     type Error;
 
@@ -37,59 +37,66 @@ pub trait SingleRead<Word,U> {
     /// pub fn try_read(&mut self, address: Address) -> nb::Result<u8, Self::Error>
     ///     let address = address.0 as *const _;
     ///     unsafe {
-    ///         Ok(core::slice::from_raw_parts::<'static, u8>(address,length)) 
+    ///         Ok(core::slice::from_raw_parts::<'static, u8>(address,length))
     ///     }
     /// ```
     fn try_read(&mut self, address: Address<U>) -> nb::Result<Word, Self::Error>;
-
 }
 
 /// Write a single word to the device.
 ///
 /// `Word` type allows any word size to be used.
-pub trait SingleWrite<Word,U> {
+pub trait SingleWrite<Word, U> {
     /// An enumeration of Storage errors
     type Error;
 
     /// Writes the word to the address
     fn try_write(&mut self, address: Address<U>, word: Word) -> nb::Result<(), Self::Error>;
-
 }
 
 /// Read multiple bytes from the device.
 ///
 /// Intended to be used for when there is a optimized method of reading multiple bytes.
-/// 
+///
 /// Iterating over the slice is a valid method to ```impl``` this trait.
-pub trait MultiRead<Word,U> {
+pub trait MultiRead<Word, U> {
     /// An enumeration of Storage errors
     type Error;
 
     /// Reads the words stored at the address to fill the buffer
     /// ```
-    /// pub fn try_read_slice(&mut self, address: Address,  buf: &mut [Word]) -> nb::Result<Word, Self::Error>
+    /// pub fn try_read_slice(
+    ///     &mut self,
+    ///     address: Address,  
+    ///     buf: &mut [Word]
+    /// ) -> nb::Result<Word, Self::Error>
     ///     let address = address.0 as *const _;
     ///     unsafe {
     ///         buf = core::slice::from_raw_parts::<'static, Word>(address,buf.len())
     ///     }
     ///     
-    ///     Ok() 
+    ///     Ok()
     /// }
     /// ```
-    fn try_read_slice(&mut self, address: Address<U>, buf: &mut [Word]) -> nb::Result<(), Self::Error>;
+    fn try_read_slice(
+        &mut self,
+        address: Address<U>,
+        buf: &mut [Word],
+    ) -> nb::Result<(), Self::Error>;
 }
 
 /// Write multiple bytes to the device.
 ///
 /// Intended to be used for when there is a optimized method of reading multiple bytes.
-/// 
+///
 /// Iterating over the slice is a valid method to ```impl``` this trait.
-pub trait MultiWrite<Word,U> {
+pub trait MultiWrite<Word, U> {
     /// An enumeration of Storage errors
     type Error;
 
     /// Writes the buffer to the address
-    fn try_write_slice(&mut self, address: Address<U>, buf: &[Word]) -> nb::Result<(), Self::Error>;
+    fn try_write_slice(&mut self, address: Address<U>, buf: &[Word])
+        -> nb::Result<(), Self::Error>;
 }
 
 /// A common interface to erase pages or memory locations.
@@ -115,12 +122,12 @@ pub trait ErasePage<U> {
 /// Allow for checking that data can fit before writing to the device.
 ///
 /// As some devices have limits on writing accross pages, the page size is also included.
- pub trait StorageSize<Word,U> {
+pub trait StorageSize<Word, U> {
     /// An enumeration of Storage errors
     type Error;
 
     /// Returns the start address and the maximum size that can be stored by the device
-    fn try_total_size(&mut self) -> nb::Result<(Address<U>,AddressOffset<U>), Self::Error>;
+    fn try_total_size(&mut self) -> nb::Result<(Address<U>, AddressOffset<U>), Self::Error>;
     /// For devices that are paged, this should return the size of the page
     ///
     /// For non paged devices, this should return the AddressOffset in ```try_total_size```

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,32 +4,49 @@
 
 use nb;
 
+/// Address should be an Unsigned int that is used to represent the address space. This allows for devices that have bigger or smaller address spaces than the host
+pub struct Address<U>(U);
+/// Address Offset should be an Unsigned int that is used to represent an optional offset from the base address
+pub struct AddressOffset<U>();
+
+use core::ops::Add;
+
+/// Implement add for the Address and AddressOffset Types
+impl Add for Address<U> {
+    type Output = Self;
+
+    fn add(self, other: AddressOffset<U>) -> Self {
+        self.0 + other.0
+    }
+
+}
+
 /// Read a single word from the device
 /// `Word` type allows any word size to be used
-pub trait SingleRead<Word> {
+pub trait SingleRead<Word,U> {
     /// An enumeration of Storage errors
     type Error;
 
     /// Reads the word stored at the address
     /// ```
-    /// pub fn try_read(&mut self, address: usize) -> nb::Result<u8, Self::Error>
+    /// pub fn try_read(&mut self, address: Address) -> nb::Result<u8, Self::Error>
     ///     let address = address as *const _;
     ///     unsafe {
     ///         Ok(core::slice::from_raw_parts::<'static, u8>(address,length)) 
     ///     }
     /// ```
-    fn try_read(&mut self, address: usize) -> nb::Result<Word, Self::Error>;
+    fn try_read(&mut self, address: Address<U>) -> nb::Result<Word, Self::Error>;
 
 }
 
 /// Write a single word to the device
 /// `Word` type allows any word size to be used
-pub trait SingleWrite<Word> {
+pub trait SingleWrite<Word,U> {
     /// An enumeration of Storage errors
     type Error;
 
     /// Writes the word to the address
-    fn try_write(&mut self, address: usize, word: Word) -> nb::Result<(), Self::Error>;
+    fn try_write(&mut self, address: Address<U>, word: Word) -> nb::Result<(), Self::Error>;
 
 }
 
@@ -37,13 +54,13 @@ pub trait SingleWrite<Word> {
 /// Intended to be used for when there is a optimized method of reading multiple bytes
 /// 
 /// Iterating over the slice is a valid method to ```impl``` this trait
-pub trait MultiRead<Word> {
+pub trait MultiRead<Word,U> {
     /// An enumeration of Storage errors
     type Error;
 
     /// Reads the words stored at the address to fill the buffer
     /// ```
-    /// pub fn try_read_slice(&mut self, address: usize,  buf: &mut [Word]) -> nb::Result<Word, Self::Error>
+    /// pub fn try_read_slice(&mut self, address: Address,  buf: &mut [Word]) -> nb::Result<Word, Self::Error>
     ///     let address = address as *const _;
     ///     unsafe {
     ///         buf = core::slice::from_raw_parts::<'static, Word>(address,buf.len())
@@ -52,28 +69,41 @@ pub trait MultiRead<Word> {
     ///     Ok() 
     /// }
     /// ```
-    fn try_read_slice(&mut self, address: usize, buf: &mut [Word]) -> nb::Result<(), Self::Error>;
+    fn try_read_slice(&mut self, address: Address<U>, buf: &mut [Word]) -> nb::Result<(), Self::Error>;
 }
 
 /// Write multiple bytes to the device
 /// Intended to be used for when there is a optimized method of reading multiple bytes
 /// 
 /// Iterating over the slice is a valid method to ```impl``` this trait
-pub trait MultiWrite<Word> {
+pub trait MultiWrite<Word,U> {
     /// An enumeration of Storage errors
     type Error;
 
     /// Writes the buffer to the address
-    fn try_write_slice(&mut self, address: usize, buf: &[Word]) -> nb::Result<(), Self::Error>;
+    fn try_write_slice(&mut self, address: Address<U>, buf: &[Word]) -> nb::Result<(), Self::Error>;
 }
 
-/// For Flash storage, the write functions can't set a bit to 1. To enable a complete rewrite flash, it needs to be cleared beforehand
-/// For non flash devices, this trait is not required, but it can be used to clear data as recommended by the device
-pub trait ClearPage<Word> {
+/// For Flash storage, the write functions can't set a bit to 1. To enable a complete rewrite flash, it needs to be erased beforehand
+/// For non flash devices, this trait is not required, but it can be used to erase data as recommended by the device (EG set all fields to 0)
+pub trait ErasePage<Word,U> {
     /// An enumeration of Storage errors
     type Error;
 
-    /// Clear the page of memory at the address
+    /// Erase the page of memory at the address
     /// For flash devices, this sets the whole page to 0xFF
-    fn try_clear(&mut self, address: usize) -> nb::Result<(), Self::Error>;
+    /// Implementations should mask the address as required to get the page to erase
+    fn try_erase(&mut self, address: Address<U>) -> nb::Result<(), Self::Error>;
+}
+
+ pub trait StorageSize<Word,U> {
+    /// An enumeration of Storage errors
+    type Error;
+
+    /// Returns the start address and the maximum size that can be stored by the device
+    fn try_total_size(&mut self) -> nb::Result<(Address<U>,AddressOffset<U>), Self::Error>;
+    /// For devices that are paged, this should return the size of the page
+    ///
+    /// For non paged devices, this should return the AddressOffset in ```try_total_size```
+    fn try_page_size(&mut self) -> nb::Result<AddressOffset<U>, Self::Error>;
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,7 +1,7 @@
 //! Storage
-/// The Read and Write traits are seperate to allow for Read Only Memory as well as Read and Write
-///
-/// Example implementations include:
+/// Traits to allow on and off board storage deivces to read and write data
+/// Allows for Read Only Memory as well as Read and Write Memory
+
 
 use nb;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -7,7 +7,7 @@ use nb;
 /// Address should be an Unsigned int that is used to represent the address space. This allows for devices that have bigger or smaller address spaces than the host
 pub struct Address<U>(U);
 /// Address Offset should be an Unsigned int that is used to represent an optional offset from the base address
-pub struct AddressOffset<U>();
+pub struct AddressOffset<U>(U);
 
 use core::ops::Add;
 
@@ -20,6 +20,9 @@ impl Add for Address<U> {
     }
 
 }
+
+/// Page should be an Unsigned int that is used to represent a Page ID in the Device Memory Space
+pub struct Page<U>(U);
 
 /// Read a single word from the device
 /// `Word` type allows any word size to be used
@@ -90,10 +93,10 @@ pub trait ErasePage<U> {
     /// An enumeration of Storage errors
     type Error;
 
-    /// Erase the page of memory at the address
+    /// Erase the page of memory
     /// For flash devices, this sets the whole page to 0xFF
     /// Implementations should mask the address as required to get the page to erase
-    fn try_erase(&mut self, address: Address<U>) -> nb::Result<(), Self::Error>;
+    fn try_erase(&mut self, page: Page<U>) -> nb::Result<(), Self::Error>;
 }
 
  pub trait StorageSize<Word,U> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -35,7 +35,7 @@ where
 }
 
 /// Page represents an unsigned integer that is a Page ID in the device memory space.
-pub struct Page<U>(U);
+pub struct Page<U>(pub U);
 
 /// Read a single word from the device.
 ///
@@ -144,8 +144,8 @@ pub trait StorageSize<Word, U> {
     /// Returns the maximum number of words that can be stored by the device
     fn try_total_size(&mut self) -> nb::Result<AddressOffset<U>, Self::Error>;
 
-    /// For devices that are paged, this should return the number of words of the page
+    /// For devices that are paged, this should return the number of words of the page referenced in the address
     ///
     /// For non paged devices, this should return the AddressOffset in ```try_total_size```
-    fn try_page_size(&mut self) -> nb::Result<AddressOffset<U>, Self::Error>;
+    fn try_page_size(&mut self, address: Address<U>) -> nb::Result<AddressOffset<U>, Self::Error>;
 }


### PR DESCRIPTION
Closes #28
These are a set of traits that can be used for on and off board storage.

Each function is split into its own trait to deal with the different types of memory (Particularly Read Only vs Read/Write)

MCU Flash impl:
https://github.com/tl8roy/alt-stm32f30x-hal/blob/master/src/storage.rs

I2C EEPROM impl:
https://github.com/tl8roy/eeprom24x-rs/blob/master/src/eeprom24x.rs

SPI PSRAM implementation:
https://github.com/tl8roy/esp_psram
This is a completely new implementation using SPI.

Feedback has come from #28, https://github.com/diondokter/device-driver/issues/1 and twitter https://twitter.com/tl8roy/status/1287254634512310272
