### PR TITLE
[0.2.x] Use nb version 0.1.3 for compatibility with nb 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-features = false
 version = "1.0.2"
 
 [dependencies.nb]
-version = "0.1.1"
+version = "0.1.3"
 
 [dev-dependencies]
 stm32f30x = "0.8.0"


### PR DESCRIPTION
With `nb` < `0.1.3` other crates cannot use `nb` `1.0` as the types will not match.
A new release of 0.2.x including this would be good.