### PR TITLE
Remove futures examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches: [ staging, trying, master ]
+  pull_request:
+
+name: Test Suite
+
+jobs:
+  ci-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable]
+
+        include:
+          - rust: 1.36.0 # Higher than the MSRV due to dependencies.
+            TARGET: x86_64-unknown-linux-gnu
+
+          # Test nightly but don't fail
+          - rust: nightly
+            experimental: true
+            TARGET: x86_64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.TARGET }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ version = "1.0.0-alpha.1"
 [dependencies]
 nb = "1"
 
-[dev-dependencies]
-futures = "0.1.17"
-
 [dev-dependencies.stm32f1]
 version = "0.12"
 features = ["stm32f103", "rt"]


### PR DESCRIPTION
The `futures`-based examples are stuck on `futures` `0.1`, require nightly to run the tests and do not represent how asynchronous processing will be done in embedded any more.
In the `0.2.x` version these examples are still present. See [here](https://docs.rs/embedded-hal/0.2.4/embedded_hal/).
See [async/await on embedded Rust](https://ferrous-systems.com/blog/async-on-embedded/).
See #251 