### PR TITLE
Release version 1.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-
 ## [Unreleased]
+
+### Added
+
+### Changed
+
+
+## [v1.0.0-alpha.2] - 2020-10-16
+
+*** This is (also) an alpha release with breaking changes (sorry) ***
 
 ### Added
 - 10-bit addressing mode for I2C traits.
@@ -129,7 +137,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.1...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.2...HEAD
+[v1.0.0-alpha.2]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.1...v1.0.0-alpha.2
 [v1.0.0-alpha.1]: https://github.com/rust-embedded/embedded-hal/compare/v0.2.3...v1.0.0-alpha.1
 [v0.2.3]: https://github.com/rust-embedded/embedded-hal/compare/v0.2.2...v0.2.3
 [v0.2.2]: https://github.com/rust-embedded/embedded-hal/compare/v0.2.1...v0.2.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 
 [dependencies]
 nb = "1"


### PR DESCRIPTION
i forgot about bors and `cargo-release`'d this so, package is already live on crates.io :-/

(maybe it would be worth looking into releasing with tags via CI? but perhaps this is also more annoying)

related to #177 