### PR TITLE
Update manifest/changelog for v1.0.0-alpha.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+
+## [v1.0.0-alpha.3] - 2020-11-04
+
+### Added
 - `Transactional` SPI interface for executing groups of SPI transactions.
 - `Transactional` I2C interface for executing groups of I2C transactions.
 
@@ -139,7 +146,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.2...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.3...HEAD
+[v1.0.0-alpha.3]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.2...v1.0.0-alpha.3
 [v1.0.0-alpha.2]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.1...v1.0.0-alpha.2
 [v1.0.0-alpha.1]: https://github.com/rust-embedded/embedded-hal/compare/v0.2.3...v1.0.0-alpha.1
 [v0.2.3]: https://github.com/rust-embedded/embedded-hal/compare/v0.2.2...v0.2.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 authors = [
+  "The Embedded HAL Team <embedded-hal@teams.rust-embedded.org>",
   "Jorge Aparicio <jorge@japaric.io>",
   "Jonathan 'theJPster' Pallant <github@thejpster.org.uk>"
 ]
@@ -12,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 
 [dependencies]
 nb = "1"


### PR DESCRIPTION
How do we feel about another alpha release now we've landed transactional SPI and I2C?

- Updated version in `Cargo.toml`
- Updated `CHANGELOG.md`

Note: create `v1.0.0-alpha.3` tag following merge