### PR TITLE
Embedded-hal 1.0.0-alpha.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+## [v1.0.0-alpha.4] - 2020-11-11
+
 ### Fixed
 - Support for I2C addressing modes in `Transactional` I2C traits.
 
@@ -148,7 +150,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.3...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.4...HEAD
+[v1.0.0-alpha.4]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.3...v1.0.0-alpha.4
 [v1.0.0-alpha.3]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.2...v1.0.0-alpha.3
 [v1.0.0-alpha.2]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.1...v1.0.0-alpha.2
 [v1.0.0-alpha.1]: https://github.com/rust-embedded/embedded-hal/compare/v0.2.3...v1.0.0-alpha.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.3" # remember to update html_root_url
 
 [dependencies]
 nb = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "1.0.0-alpha.3" # remember to update html_root_url
+version = "1.0.0-alpha.4" # remember to update html_root_url
 
 [dependencies]
 nb = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,7 @@
 //! # fn main() {}
 //! ```
 
+#![doc(html_root_url = "https://docs.rs/embedded-hal/1.0.0-alpha.3")]
 #![deny(missing_docs)]
 #![no_std]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,7 +404,7 @@
 //! # fn main() {}
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/embedded-hal/1.0.0-alpha.3")]
+#![doc(html_root_url = "https://docs.rs/embedded-hal/1.0.0-alpha.4")]
 #![deny(missing_docs)]
 #![no_std]
 


### PR DESCRIPTION
Once we have a new alpha release we can move forward with merging https://github.com/rust-embedded/linux-embedded-hal/pull/44 
I also added the `html_root_url`, which is annoying but necessary according to the Rust API guidelines.