### PR TITLE
extend core::fmt impl to cover all lifetimes

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -3,7 +3,7 @@
 //! TODO write example of usage
 use core::fmt::{Result, Write};
 
-impl<Word, Error> Write for dyn (crate::serial::Write<Word, Error = Error>)
+impl<Word, Error> Write for dyn crate::serial::Write<Word, Error = Error> + '_
 where
     Word: From<u8>,
 {


### PR DESCRIPTION
Without this, code like this doesn't build:

```rust
fn what<'a, E>(tx: &'a mut dyn hal::serial::Write<u8, Error=E>) {
    tx.write_char('a');
}
```

```
error[E0308]: mismatched types
   --> src/main.rs:136:8
    |
136 |     tx.write_char('a');
    |        ^^^^^^^^^^ lifetime mismatch
    |
    = note: expected trait `core::fmt::Write`
               found trait `core::fmt::Write`
note: the lifetime `'a` as defined on the function body at 135:9...
   --> src/main.rs:135:9
    |
135 | fn what<'a, E>(tx: &'a mut dyn hal::serial::Write<u8, Error=E>) {
    |         ^^
    = note: ...does not necessarily outlive the static lifetime
```