### PR TITLE
Remove try_ prefix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Swap PWM channel arguments to references
+- All trait methods have been renamed to remove the `try_` prefix (i.e. `try_send` -> `send`) for consistency.
 
 ## [v1.0.0-alpha.4] - 2020-11-11
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -73,7 +73,7 @@ pub trait Channel<ADC> {
 /// {
 ///    type Error = ();
 ///
-///    fn try_read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+///    fn read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
 ///        let chan = 1 << pin.channel();
 ///        self.power_up();
 ///        let result = self.do_conversion(chan);
@@ -90,5 +90,5 @@ pub trait OneShot<ADC, Word, Pin: Channel<ADC>> {
     ///
     /// This method takes a `Pin` reference, as it is expected that the ADC will be able to sample
     /// whatever channel underlies the pin.
-    fn try_read(&mut self, pin: &mut Pin) -> nb::Result<Word, Self::Error>;
+    fn read(&mut self, pin: &mut Pin) -> nb::Result<Word, Self::Error>;
 }

--- a/src/blocking/delay.rs
+++ b/src/blocking/delay.rs
@@ -16,7 +16,7 @@ pub trait DelayMs<UXX> {
     type Error;
 
     /// Pauses execution for `ms` milliseconds
-    fn try_delay_ms(&mut self, ms: UXX) -> Result<(), Self::Error>;
+    fn delay_ms(&mut self, ms: UXX) -> Result<(), Self::Error>;
 }
 
 /// Microsecond delay
@@ -28,5 +28,5 @@ pub trait DelayUs<UXX> {
     type Error;
 
     /// Pauses execution for `us` microseconds
-    fn try_delay_us(&mut self, us: UXX) -> Result<(), Self::Error>;
+    fn delay_us(&mut self, us: UXX) -> Result<(), Self::Error>;
 }

--- a/src/blocking/rng.rs
+++ b/src/blocking/rng.rs
@@ -12,5 +12,5 @@ pub trait Read {
     ///
     /// If this function returns an error, it is unspecified how many bytes it has read, but it
     /// will never read more than would be necessary to completely fill the buffer.
-    fn try_read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error>;
+    fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error>;
 }

--- a/src/blocking/serial.rs
+++ b/src/blocking/serial.rs
@@ -10,13 +10,13 @@ pub trait Write<Word> {
     /// An implementation can choose to buffer the write, returning `Ok(())`
     /// after the complete slice has been written to a buffer, but before all
     /// words have been sent via the serial interface. To make sure that
-    /// everything has been sent, call [`try_bflush`] after this function returns.
+    /// everything has been sent, call [`bflush`] after this function returns.
     ///
-    /// [`try_bflush`]: #tymethod.bflush
-    fn try_bwrite_all(&mut self, buffer: &[Word]) -> Result<(), Self::Error>;
+    /// [`bflush`]: #tymethod.bflush
+    fn bwrite_all(&mut self, buffer: &[Word]) -> Result<(), Self::Error>;
 
     /// Block until the serial interface has sent all buffered words
-    fn try_bflush(&mut self) -> Result<(), Self::Error>;
+    fn bflush(&mut self) -> Result<(), Self::Error>;
 }
 
 /// Blocking serial write
@@ -38,16 +38,16 @@ pub mod write {
     {
         type Error = S::Error;
 
-        fn try_bwrite_all(&mut self, buffer: &[Word]) -> Result<(), Self::Error> {
+        fn bwrite_all(&mut self, buffer: &[Word]) -> Result<(), Self::Error> {
             for word in buffer {
-                nb::block!(self.try_write(word.clone()))?;
+                nb::block!(self.write(word.clone()))?;
             }
 
             Ok(())
         }
 
-        fn try_bflush(&mut self) -> Result<(), Self::Error> {
-            nb::block!(self.try_flush())?;
+        fn bflush(&mut self) -> Result<(), Self::Error> {
+            nb::block!(self.flush())?;
             Ok(())
         }
     }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -22,10 +22,10 @@ use nb;
 /// #       Capture1
 ///     };
 ///
-///     capture.try_set_resolution(1.ms()).unwrap();
+///     capture.set_resolution(1.ms()).unwrap();
 ///
-///     let before = block!(capture.try_capture(Channel::_1)).unwrap();
-///     let after = block!(capture.try_capture(Channel::_1)).unwrap();
+///     let before = block!(capture.capture(Channel::_1)).unwrap();
+///     let after = block!(capture.capture(Channel::_1)).unwrap();
 ///
 ///     let period = after.wrapping_sub(before);
 ///
@@ -43,11 +43,11 @@ use nb;
 /// #     type Capture = u16;
 /// #     type Channel = Channel;
 /// #     type Time = MilliSeconds;
-/// #     fn try_capture(&mut self, _: Channel) -> ::nb::Result<u16, Self::Error> { Ok(0) }
-/// #     fn try_disable(&mut self, _: Channel) -> Result<(), Self::Error> { unimplemented!() }
-/// #     fn try_enable(&mut self, _: Channel) -> Result<(), Self::Error> { unimplemented!() }
-/// #     fn try_get_resolution(&self) -> Result<MilliSeconds, Self::Error> { unimplemented!() }
-/// #     fn try_set_resolution<T>(&mut self, _: T) -> Result<(), Self::Error> where T: Into<MilliSeconds> { Ok(()) }
+/// #     fn capture(&mut self, _: Channel) -> ::nb::Result<u16, Self::Error> { Ok(0) }
+/// #     fn disable(&mut self, _: Channel) -> Result<(), Self::Error> { unimplemented!() }
+/// #     fn enable(&mut self, _: Channel) -> Result<(), Self::Error> { unimplemented!() }
+/// #     fn get_resolution(&self) -> Result<MilliSeconds, Self::Error> { unimplemented!() }
+/// #     fn set_resolution<T>(&mut self, _: T) -> Result<(), Self::Error> where T: Into<MilliSeconds> { Ok(()) }
 /// # }
 /// ```
 // unproven reason: pre-singletons API. With singletons a `CapturePin` (cf. `PwmPin`) trait seems more
@@ -78,19 +78,19 @@ pub trait Capture {
     ///
     /// NOTE that you must multiply the returned value by the *resolution* of
     /// this `Capture` interface to get a human time unit (e.g. seconds)
-    fn try_capture(&mut self, channel: Self::Channel) -> nb::Result<Self::Capture, Self::Error>;
+    fn capture(&mut self, channel: Self::Channel) -> nb::Result<Self::Capture, Self::Error>;
 
     /// Disables a capture `channel`
-    fn try_disable(&mut self, channel: Self::Channel) -> Result<(), Self::Error>;
+    fn disable(&mut self, channel: Self::Channel) -> Result<(), Self::Error>;
 
     /// Enables a capture `channel`
-    fn try_enable(&mut self, channel: Self::Channel) -> Result<(), Self::Error>;
+    fn enable(&mut self, channel: Self::Channel) -> Result<(), Self::Error>;
 
     /// Returns the current resolution
-    fn try_get_resolution(&self) -> Result<Self::Time, Self::Error>;
+    fn get_resolution(&self) -> Result<Self::Time, Self::Error>;
 
     /// Sets the resolution of the capture timer
-    fn try_set_resolution<R>(&mut self, resolution: R) -> Result<(), Self::Error>
+    fn set_resolution<R>(&mut self, resolution: R) -> Result<(), Self::Error>
     where
         R: Into<Self::Time>;
 }

--- a/src/digital.rs
+++ b/src/digital.rs
@@ -49,22 +49,22 @@ pub trait OutputPin {
     ///
     /// *NOTE* the actual electrical state of the pin may not actually be low, e.g. due to external
     /// electrical sources
-    fn try_set_low(&mut self) -> Result<(), Self::Error>;
+    fn set_low(&mut self) -> Result<(), Self::Error>;
 
     /// Drives the pin high
     ///
     /// *NOTE* the actual electrical state of the pin may not actually be high, e.g. due to external
     /// electrical sources
-    fn try_set_high(&mut self) -> Result<(), Self::Error>;
+    fn set_high(&mut self) -> Result<(), Self::Error>;
 
     /// Drives the pin high or low depending on the provided value
     ///
     /// *NOTE* the actual electrical state of the pin may not actually be high or low, e.g. due to external
     /// electrical sources
-    fn try_set_state(&mut self, state: PinState) -> Result<(), Self::Error> {
+    fn set_state(&mut self, state: PinState) -> Result<(), Self::Error> {
         match state {
-            PinState::Low => self.try_set_low(),
-            PinState::High => self.try_set_high(),
+            PinState::Low => self.set_low(),
+            PinState::High => self.set_high(),
         }
     }
 }
@@ -74,12 +74,12 @@ pub trait StatefulOutputPin: OutputPin {
     /// Is the pin in drive high mode?
     ///
     /// *NOTE* this does *not* read the electrical state of the pin
-    fn try_is_set_high(&self) -> Result<bool, Self::Error>;
+    fn is_set_high(&self) -> Result<bool, Self::Error>;
 
     /// Is the pin in drive low mode?
     ///
     /// *NOTE* this does *not* read the electrical state of the pin
-    fn try_is_set_low(&self) -> Result<bool, Self::Error>;
+    fn is_set_low(&self) -> Result<bool, Self::Error>;
 }
 
 /// Output pin that can be toggled
@@ -93,7 +93,7 @@ pub trait ToggleableOutputPin {
     type Error;
 
     /// Toggle pin output.
-    fn try_toggle(&mut self) -> Result<(), Self::Error>;
+    fn toggle(&mut self) -> Result<(), Self::Error>;
 }
 
 /// If you can read **and** write the output state, a pin is
@@ -112,21 +112,21 @@ pub trait ToggleableOutputPin {
 /// impl OutputPin for MyPin {
 ///    type Error = Infallible;
 ///
-///    fn try_set_low(&mut self) -> Result<(), Self::Error> {
+///    fn set_low(&mut self) -> Result<(), Self::Error> {
 ///        self.state = false;
 ///        Ok(())
 ///    }
-///    fn try_set_high(&mut self) -> Result<(), Self::Error> {
+///    fn set_high(&mut self) -> Result<(), Self::Error> {
 ///        self.state = true;
 ///        Ok(())
 ///    }
 /// }
 ///
 /// impl StatefulOutputPin for MyPin {
-///    fn try_is_set_low(&self) -> Result<bool, Self::Error> {
+///    fn is_set_low(&self) -> Result<bool, Self::Error> {
 ///        Ok(!self.state)
 ///    }
-///    fn try_is_set_high(&self) -> Result<bool, Self::Error> {
+///    fn is_set_high(&self) -> Result<bool, Self::Error> {
 ///        Ok(self.state)
 ///    }
 /// }
@@ -135,10 +135,10 @@ pub trait ToggleableOutputPin {
 /// impl toggleable::Default for MyPin {}
 ///
 /// let mut pin = MyPin { state: false };
-/// pin.try_toggle().unwrap();
-/// assert!(pin.try_is_set_high().unwrap());
-/// pin.try_toggle().unwrap();
-/// assert!(pin.try_is_set_low().unwrap());
+/// pin.toggle().unwrap();
+/// assert!(pin.is_set_high().unwrap());
+/// pin.toggle().unwrap();
+/// assert!(pin.is_set_low().unwrap());
 /// ```
 pub mod toggleable {
     use super::{OutputPin, StatefulOutputPin, ToggleableOutputPin};
@@ -153,11 +153,11 @@ pub mod toggleable {
         type Error = P::Error;
 
         /// Toggle pin output
-        fn try_toggle(&mut self) -> Result<(), Self::Error> {
-            if self.try_is_set_low()? {
-                self.try_set_high()
+        fn toggle(&mut self) -> Result<(), Self::Error> {
+            if self.is_set_low()? {
+                self.set_high()
             } else {
-                self.try_set_low()
+                self.set_low()
             }
         }
     }
@@ -169,8 +169,8 @@ pub trait InputPin {
     type Error;
 
     /// Is the input pin high?
-    fn try_is_high(&self) -> Result<bool, Self::Error>;
+    fn is_high(&self) -> Result<bool, Self::Error>;
 
     /// Is the input pin low?
-    fn try_is_low(&self) -> Result<bool, Self::Error>;
+    fn is_low(&self) -> Result<bool, Self::Error>;
 }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -11,7 +11,7 @@ where
         let _ = s
             .as_bytes()
             .into_iter()
-            .map(|c| nb::block!(self.try_write(Word::from(*c))))
+            .map(|c| nb::block!(self.write(Word::from(*c))))
             .last();
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,10 +75,10 @@
 //!     type Error;
 //!
 //!     /// Reads a single byte
-//!     fn try_read(&mut self) -> nb::Result<u8, Self::Error>;
+//!     fn read(&mut self) -> nb::Result<u8, Self::Error>;
 //!
 //!     /// Writes a single byte
-//!     fn try_write(&mut self, byte: u8) -> nb::Result<(), Self::Error>;
+//!     fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error>;
 //! }
 //! ```
 //!
@@ -103,7 +103,7 @@
 //!     // ..
 //!
 //!     /// "waits" until the count down is over
-//!     fn try_wait(&mut self) -> nb::Result<(), Infallible>;
+//!     fn wait(&mut self) -> nb::Result<(), Infallible>;
 //! }
 //!
 //! # fn main() {}
@@ -148,7 +148,7 @@
 //! impl hal::serial::Read<u8> for Serial<USART1> {
 //!     type Error = Error;
 //!
-//!     fn try_read(&mut self) -> nb::Result<u8, Error> {
+//!     fn read(&mut self) -> nb::Result<u8, Error> {
 //!         // read the status register
 //!         let isr = self.usart.isr.read();
 //!
@@ -170,13 +170,13 @@
 //! impl hal::serial::Write<u8> for Serial<USART1> {
 //!     type Error = Error;
 //!
-//!     fn try_write(&mut self, byte: u8) -> nb::Result<(), Error> {
-//!         // Similar to the `try_read` implementation
+//!     fn write(&mut self, byte: u8) -> nb::Result<(), Error> {
+//!         // Similar to the `read` implementation
 //!         # Ok(())
 //!     }
 //!
-//!     fn try_flush(&mut self) -> nb::Result<(), Error> {
-//!         // Similar to the `try_read` implementation
+//!     fn flush(&mut self) -> nb::Result<(), Error> {
+//!         // Similar to the `read` implementation
 //!         # Ok(())
 //!     }
 //! }
@@ -208,9 +208,9 @@
 //! };
 //!
 //! for byte in b"Hello, world!" {
-//!     // NOTE `block!` blocks until `serial.try_write()` completes and returns
+//!     // NOTE `block!` blocks until `serial.write()` completes and returns
 //!     // `Result<(), Error>`
-//!     block!(serial.try_write(*byte)).unwrap();
+//!     block!(serial.write(*byte)).unwrap();
 //! }
 //! # }
 //!
@@ -219,7 +219,7 @@
 //! #     use core::convert::Infallible;
 //! #     pub struct Serial1;
 //! #     impl Serial1 {
-//! #         pub fn try_write(&mut self, _: u8) -> nb::Result<(), Infallible> {
+//! #         pub fn write(&mut self, _: u8) -> nb::Result<(), Infallible> {
 //! #             Ok(())
 //! #         }
 //! #     }
@@ -251,7 +251,7 @@
 //!     S: hal::serial::Write<u8>
 //! {
 //!     for &byte in buffer {
-//!         block!(serial.try_write(byte))?;
+//!         block!(serial.write(byte))?;
 //!     }
 //!
 //!     Ok(())
@@ -284,10 +284,10 @@
 //!     T: hal::timer::CountDown<Error = ()>,
 //!     S: hal::serial::Read<u8>,
 //! {
-//!     timer.try_start(timeout).map_err(Error::TimedOut)?;
+//!     timer.start(timeout).map_err(Error::TimedOut)?;
 //!
 //!     loop {
-//!         match serial.try_read() {
+//!         match serial.read() {
 //!             // raise error
 //!             Err(nb::Error::Other(e)) => return Err(Error::Serial(e)),
 //!             Err(nb::Error::WouldBlock) => {
@@ -296,9 +296,9 @@
 //!             Ok(byte) => return Ok(byte),
 //!         }
 //!
-//!         match timer.try_wait() {
+//!         match timer.wait() {
 //!             Err(nb::Error::Other(e)) => {
-//!                 // The error type specified by `timer.try_wait()` is `!`, which
+//!                 // The error type specified by `timer.wait()` is `!`, which
 //!                 // means no error can actually occur. The Rust compiler
 //!                 // still forces us to provide this match arm, though.
 //!                 unreachable!()
@@ -329,7 +329,7 @@
 //! {
 //!     loop {
 //!         if let Some(byte) = cb.peek() {
-//!             match serial.try_write(*byte) {
+//!             match serial.write(*byte) {
 //!                 Err(nb::Error::Other(_)) => unreachable!(),
 //!                 Err(nb::Error::WouldBlock) => return,
 //!                 Ok(()) => {}, // keep flushing data
@@ -391,8 +391,8 @@
 //! # struct Serial1;
 //! # impl hal::serial::Write<u8> for Serial1 {
 //! #   type Error = Infallible;
-//! #   fn try_write(&mut self, _: u8) -> nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
-//! #   fn try_flush(&mut self) -> nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
+//! #   fn write(&mut self, _: u8) -> nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
+//! #   fn flush(&mut self) -> nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
 //! # }
 //! # struct CircularBuffer;
 //! # impl CircularBuffer {

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -17,15 +17,15 @@
 /// #       Pwm1
 ///     };
 ///
-///     pwm.try_set_period(1.khz()).unwrap();
+///     pwm.set_period(1.khz()).unwrap();
 ///
-///     let max_duty = pwm.try_get_max_duty().unwrap();
+///     let max_duty = pwm.get_max_duty().unwrap();
 ///
 ///     // brightest LED
-///     pwm.try_set_duty(&Channel::_1, max_duty).unwrap();
+///     pwm.set_duty(&Channel::_1, max_duty).unwrap();
 ///
 ///     // dimmer LED
-///     pwm.try_set_duty(&Channel::_2, max_duty / 4).unwrap();
+///     pwm.set_duty(&Channel::_2, max_duty / 4).unwrap();
 /// }
 ///
 /// # use core::convert::Infallible;
@@ -39,13 +39,13 @@
 /// #     type Channel = Channel;
 /// #     type Time = KiloHertz;
 /// #     type Duty = u16;
-/// #     fn try_disable(&mut self, _: &Channel) -> Result<(), Self::Error> { unimplemented!() }
-/// #     fn try_enable(&mut self, _: &Channel) -> Result<(), Self::Error> { unimplemented!() }
-/// #     fn try_get_duty(&self, _: &Channel) -> Result<u16, Self::Error> { unimplemented!() }
-/// #     fn try_get_max_duty(&self) -> Result<u16, Self::Error> { Ok(0) }
-/// #     fn try_set_duty(&mut self, _: &Channel, _: u16) -> Result<(), Self::Error> { Ok(()) }
-/// #     fn try_get_period(&self) -> Result<KiloHertz, Self::Error> { unimplemented!() }
-/// #     fn try_set_period<T>(&mut self, _: T) -> Result<(), Self::Error> where T: Into<KiloHertz> { Ok(()) }
+/// #     fn disable(&mut self, _: &Channel) -> Result<(), Self::Error> { unimplemented!() }
+/// #     fn enable(&mut self, _: &Channel) -> Result<(), Self::Error> { unimplemented!() }
+/// #     fn get_duty(&self, _: &Channel) -> Result<u16, Self::Error> { unimplemented!() }
+/// #     fn get_max_duty(&self) -> Result<u16, Self::Error> { Ok(0) }
+/// #     fn set_duty(&mut self, _: &Channel, _: u16) -> Result<(), Self::Error> { Ok(()) }
+/// #     fn get_period(&self) -> Result<KiloHertz, Self::Error> { unimplemented!() }
+/// #     fn set_period<T>(&mut self, _: T) -> Result<(), Self::Error> where T: Into<KiloHertz> { Ok(()) }
 /// # }
 /// ```
 // unproven reason: pre-singletons API. The `PwmPin` trait seems more useful because it models independent
@@ -70,32 +70,28 @@ pub trait Pwm {
     type Duty;
 
     /// Disables a PWM `channel`
-    fn try_disable(&mut self, channel: &Self::Channel) -> Result<(), Self::Error>;
+    fn disable(&mut self, channel: &Self::Channel) -> Result<(), Self::Error>;
 
     /// Enables a PWM `channel`
-    fn try_enable(&mut self, channel: &Self::Channel) -> Result<(), Self::Error>;
+    fn enable(&mut self, channel: &Self::Channel) -> Result<(), Self::Error>;
 
     /// Returns the current PWM period
-    fn try_get_period(&self) -> Result<Self::Time, Self::Error>;
+    fn get_period(&self) -> Result<Self::Time, Self::Error>;
 
     /// Returns the current duty cycle
     ///
-    /// While the pin is transitioning to the new duty cycle after a `try_set_duty` call, this may
+    /// While the pin is transitioning to the new duty cycle after a `set_duty` call, this may
     /// return the old or the new duty cycle depending on the implementation.
-    fn try_get_duty(&self, channel: &Self::Channel) -> Result<Self::Duty, Self::Error>;
+    fn get_duty(&self, channel: &Self::Channel) -> Result<Self::Duty, Self::Error>;
 
     /// Returns the maximum duty cycle value
-    fn try_get_max_duty(&self) -> Result<Self::Duty, Self::Error>;
+    fn get_max_duty(&self) -> Result<Self::Duty, Self::Error>;
 
     /// Sets a new duty cycle
-    fn try_set_duty(
-        &mut self,
-        channel: &Self::Channel,
-        duty: Self::Duty,
-    ) -> Result<(), Self::Error>;
+    fn set_duty(&mut self, channel: &Self::Channel, duty: Self::Duty) -> Result<(), Self::Error>;
 
     /// Sets a new PWM period
-    fn try_set_period<P>(&mut self, period: P) -> Result<(), Self::Error>
+    fn set_period<P>(&mut self, period: P) -> Result<(), Self::Error>
     where
         P: Into<Self::Time>;
 }
@@ -114,20 +110,20 @@ pub trait PwmPin {
     type Duty;
 
     /// Disables a PWM `channel`
-    fn try_disable(&mut self) -> Result<(), Self::Error>;
+    fn disable(&mut self) -> Result<(), Self::Error>;
 
     /// Enables a PWM `channel`
-    fn try_enable(&mut self) -> Result<(), Self::Error>;
+    fn enable(&mut self) -> Result<(), Self::Error>;
 
     /// Returns the current duty cycle
     ///
-    /// While the pin is transitioning to the new duty cycle after a `try_set_duty` call, this may
+    /// While the pin is transitioning to the new duty cycle after a `set_duty` call, this may
     /// return the old or the new duty cycle depending on the implementation.
-    fn try_get_duty(&self) -> Result<Self::Duty, Self::Error>;
+    fn get_duty(&self) -> Result<Self::Duty, Self::Error>;
 
     /// Returns the maximum duty cycle value
-    fn try_get_max_duty(&self) -> Result<Self::Duty, Self::Error>;
+    fn get_max_duty(&self) -> Result<Self::Duty, Self::Error>;
 
     /// Sets a new duty cycle
-    fn try_set_duty(&mut self, duty: Self::Duty) -> Result<(), Self::Error>;
+    fn set_duty(&mut self, duty: Self::Duty) -> Result<(), Self::Error>;
 }

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -24,10 +24,10 @@
 ///     };
 ///
 ///
-///     let before = qei.try_count().unwrap();
-///     timer.try_start(1.s()).unwrap();
-///     block!(timer.try_wait());
-///     let after = qei.try_count().unwrap();
+///     let before = qei.count().unwrap();
+///     timer.start(1.s()).unwrap();
+///     block!(timer.wait());
+///     let after = qei.count().unwrap();
 ///
 ///     let speed = after.wrapping_sub(before);
 ///     println!("Speed: {} pulses per second", speed);
@@ -41,15 +41,15 @@
 /// # impl hal::qei::Qei for Qei1 {
 /// #     type Error = Infallible;
 /// #     type Count = u16;
-/// #     fn try_count(&self) -> Result<u16, Self::Error> { Ok(0) }
-/// #     fn try_direction(&self) -> Result<::hal::qei::Direction, Self::Error> { unimplemented!() }
+/// #     fn count(&self) -> Result<u16, Self::Error> { Ok(0) }
+/// #     fn direction(&self) -> Result<::hal::qei::Direction, Self::Error> { unimplemented!() }
 /// # }
 /// # struct Timer6;
 /// # impl hal::timer::CountDown for Timer6 {
 /// #     type Error = Infallible;
 /// #     type Time = Seconds;
-/// #     fn try_start<T>(&mut self, _: T) -> Result<(), Infallible> where T: Into<Seconds> { Ok(()) }
-/// #     fn try_wait(&mut self) -> ::nb::Result<(), Infallible> { Ok(()) }
+/// #     fn start<T>(&mut self, _: T) -> Result<(), Infallible> where T: Into<Seconds> { Ok(()) }
+/// #     fn wait(&mut self) -> ::nb::Result<(), Infallible> { Ok(()) }
 /// # }
 /// ```
 // unproven reason: needs to be re-evaluated in the new singletons world. At the very least this needs a
@@ -62,10 +62,10 @@ pub trait Qei {
     type Count;
 
     /// Returns the current pulse count of the encoder
-    fn try_count(&self) -> Result<Self::Count, Self::Error>;
+    fn count(&self) -> Result<Self::Count, Self::Error>;
 
     /// Returns the count direction
-    fn try_direction(&self) -> Result<Direction, Self::Error>;
+    fn direction(&self) -> Result<Direction, Self::Error>;
 }
 
 /// Count direction

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -10,5 +10,5 @@ pub trait Read {
     type Error;
 
     /// Get a number of bytes from the RNG.
-    fn try_read(&mut self, buf: &mut [u8]) -> nb::Result<usize, Self::Error>;
+    fn read(&mut self, buf: &mut [u8]) -> nb::Result<usize, Self::Error>;
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -11,7 +11,7 @@ pub trait Read<Word> {
     type Error;
 
     /// Reads a single word from the serial interface
-    fn try_read(&mut self) -> nb::Result<Word, Self::Error>;
+    fn read(&mut self) -> nb::Result<Word, Self::Error>;
 }
 
 /// Write half of a serial interface
@@ -20,8 +20,8 @@ pub trait Write<Word> {
     type Error;
 
     /// Writes a single word to the serial interface
-    fn try_write(&mut self, word: Word) -> nb::Result<(), Self::Error>;
+    fn write(&mut self, word: Word) -> nb::Result<(), Self::Error>;
 
     /// Ensures that none of the previously written words are still buffered
-    fn try_flush(&mut self) -> nb::Result<(), Self::Error>;
+    fn flush(&mut self) -> nb::Result<(), Self::Error>;
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -8,12 +8,12 @@ use nb;
 ///
 /// - It's the task of the user of this interface to manage the slave select lines
 ///
-/// - Due to how full duplex SPI works each `try_read` call must be preceded by a `try_send` call.
+/// - Due to how full duplex SPI works each `read` call must be preceded by a `send` call.
 ///
-/// - `try_read` calls only return the data received with the last `try_send` call.
+/// - `read` calls only return the data received with the last `send` call.
 /// Previously received data is discarded
 ///
-/// - Data is only guaranteed to be clocked out when the `try_read` call succeeds.
+/// - Data is only guaranteed to be clocked out when the `read` call succeeds.
 /// The slave select line shouldn't be released before that.
 ///
 /// - Some SPIs can work with 8-bit *and* 16-bit words. You can overload this trait with different
@@ -26,10 +26,10 @@ pub trait FullDuplex<Word> {
     ///
     /// **NOTE** A word must be sent to the slave before attempting to call this
     /// method.
-    fn try_read(&mut self) -> nb::Result<Word, Self::Error>;
+    fn read(&mut self) -> nb::Result<Word, Self::Error>;
 
     /// Sends a word to the slave
-    fn try_send(&mut self, word: Word) -> nb::Result<(), Self::Error>;
+    fn send(&mut self, word: Word) -> nb::Result<(), Self::Error>;
 }
 
 /// Clock polarity

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -6,7 +6,7 @@ use nb;
 ///
 /// # Contract
 ///
-/// - `self.start(count); block!(self.try_wait());` MUST block for AT LEAST the time specified by
+/// - `self.start(count); block!(self.wait());` MUST block for AT LEAST the time specified by
 /// `count`.
 ///
 /// *Note* that the implementer doesn't necessarily have to be a *downcounting* timer; it could also
@@ -34,8 +34,8 @@ use nb;
 ///     };
 ///
 ///     Led.on();
-///     timer.try_start(1.s()).unwrap();
-///     block!(timer.try_wait()); // blocks for 1 second
+///     timer.start(1.s()).unwrap();
+///     block!(timer.wait()); // blocks for 1 second
 ///     Led.off();
 /// }
 ///
@@ -52,8 +52,8 @@ use nb;
 /// # impl hal::timer::CountDown for Timer6 {
 /// #     type Error = Infallible;
 /// #     type Time = Seconds;
-/// #     fn try_start<T>(&mut self, _: T) -> Result<(), Self::Error> where T: Into<Seconds> { Ok(()) }
-/// #     fn try_wait(&mut self) -> ::nb::Result<(), Infallible> { Ok(()) }
+/// #     fn start<T>(&mut self, _: T) -> Result<(), Self::Error> where T: Into<Seconds> { Ok(()) }
+/// #     fn wait(&mut self) -> ::nb::Result<(), Infallible> { Ok(()) }
 /// # }
 /// ```
 pub trait CountDown {
@@ -66,7 +66,7 @@ pub trait CountDown {
     type Time;
 
     /// Starts a new count down
-    fn try_start<T>(&mut self, count: T) -> Result<(), Self::Error>
+    fn start<T>(&mut self, count: T) -> Result<(), Self::Error>
     where
         T: Into<Self::Time>;
 
@@ -76,9 +76,9 @@ pub trait CountDown {
     ///
     /// - If `Self: Periodic`, the timer will start a new count down right after the last one
     /// finishes.
-    /// - Otherwise the behavior of calling `try_wait` after the last call returned `Ok` is UNSPECIFIED.
+    /// - Otherwise the behavior of calling `wait` after the last call returned `Ok` is UNSPECIFIED.
     /// Implementers are suggested to panic on this scenario to signal a programmer error.
-    fn try_wait(&mut self) -> nb::Result<(), Self::Error>;
+    fn wait(&mut self) -> nb::Result<(), Self::Error>;
 }
 
 /// Marker trait that indicates that a timer is periodic
@@ -92,5 +92,5 @@ pub trait Cancel: CountDown {
     ///
     /// An error will be returned if the countdown has already been canceled or was never started.
     /// An error is also returned if the countdown is not `Periodic` and has already expired.
-    fn try_cancel(&mut self) -> Result<(), Self::Error>;
+    fn cancel(&mut self) -> Result<(), Self::Error>;
 }

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -10,7 +10,7 @@ pub trait Watchdog {
 
     /// Triggers the watchdog. This must be done once the watchdog is started
     /// to prevent the processor being reset.
-    fn try_feed(&mut self) -> Result<(), Self::Error>;
+    fn feed(&mut self) -> Result<(), Self::Error>;
 }
 
 /// Enables A watchdog timer to reset the processor if software is frozen or
@@ -33,7 +33,7 @@ pub trait Enable {
     ///
     /// This consumes the value and returns the `Watchdog` trait that you must
     /// `feed()`.
-    fn try_start<T>(self, period: T) -> Result<Self::Target, Self::Error>
+    fn start<T>(self, period: T) -> Result<Self::Target, Self::Error>
     where
         T: Into<Self::Time>;
 }
@@ -56,5 +56,5 @@ pub trait Disable {
     ///
     /// This stops the watchdog and returns an instance implementing the
     /// `Enable` trait so that it can be started again.
-    fn try_disable(self) -> Result<Self::Target, Self::Error>;
+    fn disable(self) -> Result<Self::Target, Self::Error>;
 }


### PR DESCRIPTION
This removes the `try_` prefix from all the trait method names, after discussion on issue #177 .