### PR TITLE
Add digital::IoPin to resolve issue 29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Added `IoPin` trait for pins that can change between being inputs or outputs
+  dynamically.
 
 ### Changed
 - Swap PWM channel arguments to references


### PR DESCRIPTION
Closes #29.

This implementation is inspired by [chrismoos's comment](https://github.com/rust-embedded/embedded-hal/issues/29#issuecomment-717590055) in #29.

I've demonstrated using this trait for a [no-std DHT11 driver](https://github.com/MorganR/rust-simple-sensors/blob/main/src/dht11.rs), and verified this on a Raspberry Pi 3B+ using an implementation in linux-embedded-hal (PR to follow). 

I'll also be sending a PR to implement this in at least one additional HAL implementation library (recommendations welcome).

One question I have is how copyright/authorship is tracked in this repo? I believe the copyright owner for my code would technically be Google LLC. When patching repos, I'm meant to add that to the appropriate copyright/authors list.