### PR TITLE
Mark RNG traits as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Swap PWM channel arguments to references
+- Marked RNG Traits as deprecated.
 
 ## [v1.0.0-alpha.4] - 2020-11-11
 

--- a/src/blocking/rng.rs
+++ b/src/blocking/rng.rs
@@ -1,5 +1,6 @@
 //! Blocking hardware random number generator
 
+#[deprecated(note = "Implement rand_core instead.")]
 /// Blocking read
 pub trait Read {
     /// Error type

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,7 +14,6 @@ pub use crate::blocking::i2c::{
     WriteIterRead as _embedded_hal_blocking_i2c_WriteIterRead,
     WriteRead as _embedded_hal_blocking_i2c_WriteRead,
 };
-pub use crate::blocking::rng::Read as _embedded_hal_blocking_rng_Read;
 pub use crate::blocking::serial::Write as _embedded_hal_blocking_serial_Write;
 pub use crate::blocking::spi::{
     Transfer as _embedded_hal_blocking_spi_Transfer, Write as _embedded_hal_blocking_spi_Write,
@@ -28,7 +27,6 @@ pub use crate::digital::ToggleableOutputPin as _embedded_hal_digital_ToggleableO
 pub use crate::pwm::Pwm as _embedded_hal_Pwm;
 pub use crate::pwm::PwmPin as _embedded_hal_PwmPin;
 pub use crate::qei::Qei as _embedded_hal_Qei;
-pub use crate::rng::Read as _embedded_hal_rng_Read;
 pub use crate::serial::Read as _embedded_hal_serial_Read;
 pub use crate::serial::Write as _embedded_hal_serial_Write;
 pub use crate::spi::FullDuplex as _embedded_hal_spi_FullDuplex;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -2,6 +2,7 @@
 
 use nb;
 
+#[deprecated(note = "Implement rand_core instead.")]
 /// Nonblocking stream of random bytes.
 pub trait Read {
     /// An enumeration of RNG errors.


### PR DESCRIPTION
This is the softer approach than the nuclear option presented in #270 or at least the first step. Would also close #128 .

I'm not super sure about the removal of the traits from the prelude. This might break stuff. Alternatively an `#[allow(deprecated)]` for these imports would work.