### PR TITLE
Some minor improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rust-embedded/hal @ilya-epifanov @thejpster
+* @rust-embedded/hal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
 
 name: Continuous integration
 
+env:
+  RUSTFLAGS: '--deny warnings'
+
 jobs:
   ci-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
 
 name: Test Suite
 
+env:
+  RUSTFLAGS: '--deny warnings'
+
 jobs:
   ci-linux:
     runs-on: ubuntu-latest

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,7 +1,5 @@
 //! Analog-digital conversion traits
 
-use nb;
-
 /// A marker trait to identify MCU pins that can be used as inputs to an ADC channel.
 ///
 /// This marker trait denotes an object, i.e. a GPIO pin, that is ready for use as an input to the

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,7 +1,5 @@
 //! Input capture
 
-use nb;
-
 /// Input capture
 ///
 /// # Examples

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -9,9 +9,8 @@ where
 {
     fn write_str(&mut self, s: &str) -> Result {
         let _ = s
-            .as_bytes()
-            .into_iter()
-            .map(|c| nb::block!(self.write(Word::from(*c))))
+            .bytes()
+            .map(|c| nb::block!(self.write(Word::from(c))))
             .last();
         Ok(())
     }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,7 +1,5 @@
 //! Serial interface
 
-use nb;
-
 /// Read half of a serial interface
 ///
 /// Some serial interfaces support different data sizes (8 bits, 9 bits, etc.);

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,7 +1,5 @@
 //! Serial Peripheral Interface
 
-use nb;
-
 /// Full duplex (master mode)
 ///
 /// # Notes

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,7 +1,5 @@
 //! Timers
 
-use nb;
-
 /// A count down timer
 ///
 /// # Contract


### PR DESCRIPTION
- Update codeowners
- Remove unnecessary imports
- Replace `into_iter()` with `iter()` when used on reference
- Deny warnings on cargo check and cargo test on CI (but allow them on clippy since that is a fast-moving target)