### PR TITLE
Add trait for count down times that allow reading out elapsed time

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -79,6 +79,12 @@ pub trait CountDown {
     fn wait(&mut self) -> nb::Result<(), Self::Error>;
 }
 
+/// A count down timer that allows reading out elapsed time since start.
+pub trait Elapsed: CountDown {
+    /// The units of time that elapsed since the timer was started.
+    fn elapsed(&self) -> Result<Self::Time, Self::Error>;
+}
+
 /// Marker trait that indicates that a timer is periodic
 pub trait Periodic {}
 


### PR DESCRIPTION
Concrete suggestion to resolve https://github.com/rust-embedded/embedded-hal/issues/186.

I'd prefer `Elapsed::elapsed` to be infallible, but that is probably against the tide of the times :)

We use pretty much this implementation in https://github.com/lpc55/lpc55-hal/blob/5c70be5f73da2a6e1330aefc82a53f6cd3ddc7d6/src/drivers/timer.rs#L43-L48

Of course this is infinitely bike-sheddable (remaining? now? etc...), it would be a pity not to have a standardized way of reading out a timer if embedded HAL is headed for a 1.0.