### PR TITLE
[RFC] blocking/serial: make method naming consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Moved all traits into two modules depending on the execution model: `blocking` and `nb` (non-blocking).
 - Re-export `nb::{block!, Error, Result}` to avoid version mismatches. These should be used instead of
   importing the `nb` crate directly in dependendent crates.
+- `blocking::Serial`: renamed `bwrite_all` to `write`, `bflush` to `flush.
 
 ## [v1.0.0-alpha.4] - 2020-11-11
 

--- a/src/blocking/serial.rs
+++ b/src/blocking/serial.rs
@@ -10,13 +10,13 @@ pub trait Write<Word> {
     /// An implementation can choose to buffer the write, returning `Ok(())`
     /// after the complete slice has been written to a buffer, but before all
     /// words have been sent via the serial interface. To make sure that
-    /// everything has been sent, call [`bflush`] after this function returns.
+    /// everything has been sent, call [`flush`] after this function returns.
     ///
-    /// [`bflush`]: #tymethod.bflush
-    fn bwrite_all(&mut self, buffer: &[Word]) -> Result<(), Self::Error>;
+    /// [`flush`]: #tymethod.flush
+    fn write(&mut self, buffer: &[Word]) -> Result<(), Self::Error>;
 
     /// Block until the serial interface has sent all buffered words
-    fn bflush(&mut self) -> Result<(), Self::Error>;
+    fn flush(&mut self) -> Result<(), Self::Error>;
 }
 
 /// Blocking serial write
@@ -38,7 +38,7 @@ pub mod write {
     {
         type Error = S::Error;
 
-        fn bwrite_all(&mut self, buffer: &[Word]) -> Result<(), Self::Error> {
+        fn write(&mut self, buffer: &[Word]) -> Result<(), Self::Error> {
             for word in buffer {
                 nb::block!(self.write(word.clone()))?;
             }
@@ -46,7 +46,7 @@ pub mod write {
             Ok(())
         }
 
-        fn bflush(&mut self) -> Result<(), Self::Error> {
+        fn flush(&mut self) -> Result<(), Self::Error> {
             nb::block!(self.flush())?;
             Ok(())
         }


### PR DESCRIPTION
`blocking::serial::Write`'s methods are named `bwrite_all` and `bflush`.

- the `b` prefix indicates blocking (I guess?). However no other blocking trait method has this prefix.
- the `_all` suffix indicates it writes a slice instead of a single word (I guess?). However, no other trait method that writes a slice has this suffix.

To make them consistent, this PR renames them to `write` and `flush`.