### PR TITLE
[RFC] Rename `send` to `write`.

### DIFF
--- a/src/blocking/i2c.rs
+++ b/src/blocking/i2c.rs
@@ -143,7 +143,7 @@ pub trait Write<A: AddressMode = SevenBitAddress> {
     /// Error type
     type Error;
 
-    /// Sends bytes to slave with address `address`
+    /// Writes bytes to slave with address `address`
     ///
     /// # I2C Events (contract)
     ///
@@ -167,7 +167,7 @@ pub trait WriteIter<A: AddressMode = SevenBitAddress> {
     /// Error type
     type Error;
 
-    /// Sends bytes to slave with address `address`
+    /// Writes bytes to slave with address `address`
     ///
     /// # I2C Events (contract)
     ///
@@ -182,7 +182,7 @@ pub trait WriteRead<A: AddressMode = SevenBitAddress> {
     /// Error type
     type Error;
 
-    /// Sends bytes to slave with address `address` and then reads enough bytes to fill `buffer` *in a
+    /// Writes bytes to slave with address `address` and then reads enough bytes to fill `buffer` *in a
     /// single transaction*
     ///
     /// # I2C Events (contract)
@@ -217,7 +217,7 @@ pub trait WriteIterRead<A: AddressMode = SevenBitAddress> {
     /// Error type
     type Error;
 
-    /// Sends bytes to slave with address `address` and then reads enough bytes to fill `buffer` *in a
+    /// Writes bytes to slave with address `address` and then reads enough bytes to fill `buffer` *in a
     /// single transaction*
     ///
     /// # I2C Events (contract)

--- a/src/blocking/spi.rs
+++ b/src/blocking/spi.rs
@@ -5,7 +5,7 @@ pub trait Transfer<W> {
     /// Error type
     type Error;
 
-    /// Sends `words` to the slave. Returns the `words` received from the slave
+    /// Writes `words` to the slave. Returns the `words` received from the slave
     fn transfer<'w>(&mut self, words: &'w mut [W]) -> Result<&'w [W], Self::Error>;
 }
 
@@ -14,7 +14,7 @@ pub trait Write<W> {
     /// Error type
     type Error;
 
-    /// Sends `words` to the slave, ignoring all the incoming words
+    /// Writes `words` to the slave, ignoring all the incoming words
     fn write(&mut self, words: &[W]) -> Result<(), Self::Error>;
 }
 
@@ -23,7 +23,7 @@ pub trait WriteIter<W> {
     /// Error type
     type Error;
 
-    /// Sends `words` to the slave, ignoring all the incoming words
+    /// Writes `words` to the slave, ignoring all the incoming words
     fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
     where
         WI: IntoIterator<Item = W>;
@@ -44,7 +44,7 @@ pub mod transfer {
 
         fn transfer<'w>(&mut self, words: &'w mut [W]) -> Result<&'w [W], S::Error> {
             for word in words.iter_mut() {
-                nb::block!(self.send(word.clone()))?;
+                nb::block!(self.write(word.clone()))?;
                 *word = nb::block!(self.read())?;
             }
 
@@ -68,7 +68,7 @@ pub mod write {
 
         fn write(&mut self, words: &[W]) -> Result<(), S::Error> {
             for word in words {
-                nb::block!(self.send(word.clone()))?;
+                nb::block!(self.write(word.clone()))?;
                 nb::block!(self.read())?;
             }
 
@@ -95,7 +95,7 @@ pub mod write_iter {
             WI: IntoIterator<Item = W>,
         {
             for word in words.into_iter() {
-                nb::block!(self.send(word.clone()))?;
+                nb::block!(self.write(word.clone()))?;
                 nb::block!(self.read())?;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@
 //!
 //! ### Blocking mode
 //!
-//! An example of sending a string over the serial interface in a blocking
+//! An example of writing a string over the serial interface in a blocking
 //! fashion:
 //!
 //! ```

--- a/src/nb/spi.rs
+++ b/src/nb/spi.rs
@@ -6,9 +6,9 @@
 ///
 /// - It's the task of the user of this interface to manage the slave select lines
 ///
-/// - Due to how full duplex SPI works each `read` call must be preceded by a `send` call.
+/// - Due to how full duplex SPI works each `read` call must be preceded by a `write` call.
 ///
-/// - `read` calls only return the data received with the last `send` call.
+/// - `read` calls only return the data received with the last `write` call.
 /// Previously received data is discarded
 ///
 /// - Data is only guaranteed to be clocked out when the `read` call succeeds.
@@ -26,8 +26,8 @@ pub trait FullDuplex<Word> {
     /// method.
     fn read(&mut self) -> nb::Result<Word, Self::Error>;
 
-    /// Sends a word to the slave
-    fn send(&mut self, word: Word) -> nb::Result<(), Self::Error>;
+    /// Writes a word to the slave
+    fn write(&mut self, word: Word) -> nb::Result<(), Self::Error>;
 }
 
 /// Clock polarity


### PR DESCRIPTION
`send` and `write` are essentially synonymous. All the traits use `write`, except `nb::spi::FullDuplex`, which uses `send`.

This PR renames it to `write`. Instances of `send` in the docs are also replaced, for consistency.