### PR TITLE
blocking/spi: Don't return the same buffer back.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `blocking::Serial`: renamed `bwrite_all` to `write`, `bflush` to `flush.
 - Removed `prelude` to avoid method name conflicts between different flavors (blocking, nb) of the same trait. Traits must now be manually imported.
 - Removed the various `Default` marker traits.
+- Removed `&[W]` returned slice in `spi::blocking::Transfer`.
 
 ### Removed
 - Removed random number generation (`rng`) traits in favor of [rand_core](https://crates.io/crates/rand_core).

--- a/src/blocking/spi.rs
+++ b/src/blocking/spi.rs
@@ -5,8 +5,10 @@ pub trait Transfer<W> {
     /// Error type
     type Error;
 
-    /// Writes `words` to the slave. Returns the `words` received from the slave
-    fn transfer<'w>(&mut self, words: &'w mut [W]) -> Result<&'w [W], Self::Error>;
+    /// Writes and reads simultaneously. The contents of `words` are
+    /// written to the slave, and the received words are stored into the same
+    /// `words` buffer, overwriting it.
+    fn transfer(&mut self, words: &mut [W]) -> Result<(), Self::Error>;
 }
 
 /// Blocking write


### PR DESCRIPTION
This is a rather minor improvement to the blocking SPI Transfer trait, but that IMO is still worth it.

Old: `fn transfer<'w>(&mut self, words: &'w mut [W]) -> Result<&'w [W], Self::Error>`
New: `fn transfer(&mut self, words: &mut [W]) -> Result<(), Self::Error>`

It is redundant (and confusing IMO) to return back the same buffer the user has passed in. It allows for 2 ways of writing the same thing: use the returned buffer, or ignore it and use the buffer that was passed in. It's not obvious which is better, and from the docs it's not obvious that both are really the same either.

Also, with the old signature, it is possible for implementors to return a subslice of the buffer instead of the whole buffer. This would be arguably wrong and would break user code that assumes the entire buffer is returned. Not re-returning the buffer makes this mistake impossible.