### PR TITLE
Added purpose and requirements to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ to access functionality not included here should interact with the intended plat
 3. Provide generic traits for other peripherals that are suitably common, and easy to abstract over
 4. Provide both blocking, and nonblocking traits for all supported communications protocols
 5. Use fallible trait methods when applicable
+6. Document each trait and method with a description, and example code
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ traits, therefore being compatible with any platform that implements them.
 This project supports the most commonly-used features of supported peipherals. Drivers that need
 to access functionality not included here should interact with the intended platform directly.
 
-## Requirements
+## Project goals
 1. Provide generic traits for GPIO, including getting and setting state (low / high)
-2. Provide generic traits to read and write using the most common communications protocols in embedded
+2. Provide generic traits to read and write using the most common communications protocols in embedded -
+these should be sufficient for most platform-driver communication
 3. Provide generic traits for other peripherals that are suitably common, and easy to abstract over
 4. Provide both blocking, and nonblocking traits for all supported communications protocols
 5. Use fallible trait methods when applicable

--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ This project is developed and maintained by the [HAL team][team].
 
 [API reference]: https://docs.rs/embedded-hal
 
+## Purpose
+This project provides traits used to write generic drivers for embedded systems. HAL libraries for
+specific platforms (microcontrollers etc) can implement these traits for peripherals such as
+General Purpose Input/Output (GPIO), and communications protocols. Drivers for specific hardware 
+devices can be written that interface with these
+traits, therefore being compatible with any platform that implements them.
+
+This project supports the most commonly-used features of supported peipherals. Drivers that need
+to access functionality not included here should interact with the intended platform directly.
+
+## Requirements
+1. Provide generic traits for GPIO, including getting and setting state (low / high)
+2. Provide generic traits to read and write using the most common communications protocols in embedded
+3. Provide generic traits for other peripherals that are suitably common, and easy to abstract over
+4. Provide both blocking, and nonblocking traits for all supported communications protocols
+5. Use fallible trait methods when applicable
+
 ## Releases
 
 At the moment we are working towards a `1.0.0` release (see [#177]). During this process we will


### PR DESCRIPTION
These sections towards the top of the readme clarify the purpose and scope of `embedded-hal`. It's intended to show users new to rust embedded how this project fits into the ecosystem.