### PR TITLE
Add error traits for communication interfaces

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,8 +5,8 @@ status = [
   "ci-linux (stable, x86_64-unknown-linux-gnu)",
   "ci-linux (stable, thumbv6m-none-eabi)",
   "ci-linux (stable, thumbv7m-none-eabi)",
-  "ci-linux (1.35.0, x86_64-unknown-linux-gnu)",
+  "ci-linux (1.40.0, x86_64-unknown-linux-gnu)",
   "ci-linux-test (stable)",
-  "ci-linux-test (1.36.0, x86_64-unknown-linux-gnu)",
+  "ci-linux-test (1.40.0, x86_64-unknown-linux-gnu)",
   "fmt",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.35.0
+          - rust: 1.40.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         rust: [stable]
 
         include:
-          - rust: 1.36.0 # Higher than the MSRV due to dependencies.
+          - rust: 1.40.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added `IoPin` trait for pins that can change between being inputs or outputs
   dynamically.
+- `Error` traits for SPI, I2C and Serial traits. The error types used in those must
+  implement these `Error` traits, which implies providing a conversion to a common
+  set of error kinds. Generic drivers using these interfaces can then convert the errors
+  to this common set to act upon them.
 - Added `Debug` to all spi mode types.
 - Add impls of all traits for references (`&T` or `&mut T` depending on the trait) when `T` implements the trait.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![crates.io](https://img.shields.io/crates/d/embedded-hal.svg)](https://crates.io/crates/embedded-hal)
 [![crates.io](https://img.shields.io/crates/v/embedded-hal.svg)](https://crates.io/crates/embedded-hal)
 [![Documentation](https://docs.rs/embedded-hal/badge.svg)](https://docs.rs/embedded-hal)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.35+-blue.svg)
+![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.40+-blue.svg)
 
 # `embedded-hal`
 
@@ -108,7 +108,7 @@ As stated before, `embedded-hal` `-alpha` versions are _not guaranteed_ to be co
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.35 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.40 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -3,7 +3,8 @@
 //! TODO write example of usage
 use core::fmt::{Result, Write};
 
-impl<Word, Error: core::fmt::Debug> Write for dyn crate::serial::nb::Write<Word, Error = Error> + '_
+impl<Word, Error: crate::serial::Error> Write
+    for dyn crate::serial::nb::Write<Word, Error = Error> + '_
 where
     Word: From<u8>,
 {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -123,9 +123,10 @@ pub enum ErrorKind {
     Bus,
     /// The arbitration was lost, e.g. electrical problems with the clock signal
     ArbitrationLoss,
-    /// A bus operation was not acknowledged, e.g. due to the addressed device not being available on
-    /// the bus or the device not being ready to process requests at the moment
-    NoAcknowledge,
+    /// The device did not acknowledge its address. The device may be missing.
+    NoAcknowledgeAddress,
+    /// The device did not acknowled the data. It may not be ready to process requests at the moment.
+    NoAcknowledgeData,
     /// The peripheral receive buffer was overrun
     Overrun,
     /// A different error occurred. The original error may contain more information.
@@ -143,7 +144,8 @@ impl core::fmt::Display for ErrorKind {
         match self {
             Self::Bus => write!(f, "Bus error occurred"),
             Self::ArbitrationLoss => write!(f, "The arbitration was lost"),
-            Self::NoAcknowledge => write!(f, "A bus operation was not acknowledged"),
+            Self::NoAcknowledgeAddress => write!(f, "The device did not acknowledge its address"),
+            Self::NoAcknowledgeData => write!(f, "The device did not acknowledge the data"),
             Self::Overrun => write!(f, "The peripheral receive buffer was overrun"),
             Self::Other => write!(
                 f,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -119,7 +119,7 @@ pub trait Error: core::fmt::Debug {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[non_exhaustive]
 pub enum ErrorKind {
-    /// An unspecific bus error occurred
+    /// Bus error occurred. e.g. A START or a STOP condition is detected and is not located after a multiple of 9 SCL clock pulses.
     Bus,
     /// The arbitration was lost, e.g. electrical problems with the clock signal
     ArbitrationLoss,
@@ -141,7 +141,7 @@ impl Error for ErrorKind {
 impl core::fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Bus => write!(f, "An unspecific bus error occurred"),
+            Self::Bus => write!(f, "Bus error occurred"),
             Self::ArbitrationLoss => write!(f, "The arbitration was lost"),
             Self::NoAcknowledge => write!(f, "A bus operation was not acknowledged"),
             Self::Overrun => write!(f, "The peripheral receive buffer was overrun"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,24 +143,16 @@
 //! // convenience type alias
 //! pub type Serial1 = Serial<USART1>;
 //!
-//! /// Serial interface error
-//! #[derive(Debug)]
-//! pub enum Error {
-//!     /// Buffer overrun
-//!     Overrun,
-//!     // omitted: other error variants
-//! }
-//!
 //! impl hal::serial::nb::Read<u8> for Serial<USART1> {
-//!     type Error = Error;
+//!     type Error = hal::serial::ErrorKind;
 //!
-//!     fn read(&mut self) -> nb::Result<u8, Error> {
+//!     fn read(&mut self) -> nb::Result<u8, Self::Error> {
 //!         // read the status register
 //!         let isr = self.usart.sr.read();
 //!
 //!         if isr.ore().bit_is_set() {
 //!             // Error: Buffer overrun
-//!             Err(nb::Error::Other(Error::Overrun))
+//!             Err(nb::Error::Other(Self::Error::Overrun))
 //!         }
 //!         // omitted: checks for other errors
 //!         else if isr.rxne().bit_is_set() {
@@ -174,14 +166,14 @@
 //! }
 //!
 //! impl hal::serial::nb::Write<u8> for Serial<USART1> {
-//!     type Error = Error;
+//!     type Error = hal::serial::ErrorKind;
 //!
-//!     fn write(&mut self, byte: u8) -> nb::Result<(), Error> {
+//!     fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
 //!         // Similar to the `read` implementation
 //!         # Ok(())
 //!     }
 //!
-//!     fn flush(&mut self) -> nb::Result<(), Error> {
+//!     fn flush(&mut self) -> nb::Result<(), Self::Error> {
 //!         // Similar to the `read` implementation
 //!         # Ok(())
 //!     }
@@ -327,12 +319,11 @@
 //! use embedded_hal as hal;
 //! use hal::nb;
 //!
-//! use hal::serial::nb::Write;
-//! use ::core::convert::Infallible;
+//! use hal::serial::{ErrorKind, nb::Write};
 //!
 //! fn flush<S>(serial: &mut S, cb: &mut CircularBuffer)
 //! where
-//!     S: hal::serial::nb::Write<u8, Error = Infallible>,
+//!     S: hal::serial::nb::Write<u8, Error = ErrorKind>,
 //! {
 //!     loop {
 //!         if let Some(byte) = cb.peek() {
@@ -397,9 +388,9 @@
 //! # }
 //! # struct Serial1;
 //! # impl hal::serial::nb::Write<u8> for Serial1 {
-//! #   type Error = Infallible;
-//! #   fn write(&mut self, _: u8) -> nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
-//! #   fn flush(&mut self) -> nb::Result<(), Infallible> { Err(::nb::Error::WouldBlock) }
+//! #   type Error = ErrorKind;
+//! #   fn write(&mut self, _: u8) -> nb::Result<(), Self::Error> { Err(::nb::Error::WouldBlock) }
+//! #   fn flush(&mut self) -> nb::Result<(), Self::Error> { Err(::nb::Error::WouldBlock) }
 //! # }
 //! # struct CircularBuffer;
 //! # impl CircularBuffer {

--- a/src/serial/blocking.rs
+++ b/src/serial/blocking.rs
@@ -7,7 +7,7 @@
 /// Write half of a serial interface (blocking variant)
 pub trait Write<Word> {
     /// The type of error that can occur when writing
-    type Error: core::fmt::Debug;
+    type Error: crate::serial::Error;
 
     /// Writes a slice, blocking until everything has been written
     ///

--- a/src/serial/mod.rs
+++ b/src/serial/mod.rs
@@ -2,3 +2,58 @@
 
 pub mod blocking;
 pub mod nb;
+
+/// Serial error
+pub trait Error: core::fmt::Debug {
+    /// Convert error to a generic serial error kind
+    ///
+    /// By using this method, serial errors freely defined by HAL implementations
+    /// can be converted to a set of generic serial errors upon which generic
+    /// code can act.
+    fn kind(&self) -> ErrorKind;
+}
+
+/// Serial error kind
+///
+/// This represents a common set of serial operation errors. HAL implementations are
+/// free to define more specific or additional error types. However, by providing
+/// a mapping to these common serial errors, generic code can still react to them.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// The peripheral receive buffer was overrun.
+    Overrun,
+    /// Received data does not conform to the peripheral configuration.
+    /// Can be caused by a misconfigured device on either end of the serial line.
+    FrameFormat,
+    /// Parity check failed.
+    Parity,
+    /// Serial line is too noisy to read valid data.
+    Noise,
+    /// A different error occurred. The original error may contain more information.
+    Other,
+}
+
+impl Error for ErrorKind {
+    fn kind(&self) -> ErrorKind {
+        *self
+    }
+}
+
+impl core::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Overrun => write!(f, "The peripheral receive buffer was overrun"),
+            Self::Parity => write!(f, "Parity check failed"),
+            Self::Noise => write!(f, "Serial line is too noisy to read valid data"),
+            Self::FrameFormat => write!(
+                f,
+                "Received data does not conform to the peripheral configuration"
+            ),
+            Self::Other => write!(
+                f,
+                "A different error occurred. The original error may contain more information"
+            ),
+        }
+    }
+}

--- a/src/serial/nb.rs
+++ b/src/serial/nb.rs
@@ -6,7 +6,7 @@
 /// This can be encoded in this trait via the `Word` type parameter.
 pub trait Read<Word> {
     /// Read error
-    type Error: core::fmt::Debug;
+    type Error: crate::serial::Error;
 
     /// Reads a single word from the serial interface
     fn read(&mut self) -> nb::Result<Word, Self::Error>;
@@ -23,7 +23,7 @@ impl<T: Read<Word>, Word> Read<Word> for &mut T {
 /// Write half of a serial interface
 pub trait Write<Word> {
     /// Write error
-    type Error: core::fmt::Debug;
+    type Error: crate::serial::Error;
 
     /// Writes a single word to the serial interface
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error>;

--- a/src/spi/blocking.rs
+++ b/src/spi/blocking.rs
@@ -7,7 +7,7 @@
 /// Blocking transfer
 pub trait Transfer<W> {
     /// Error type
-    type Error: core::fmt::Debug;
+    type Error: crate::spi::Error;
 
     /// Writes and reads simultaneously. The contents of `words` are
     /// written to the slave, and the received words are stored into the same
@@ -26,7 +26,7 @@ impl<T: Transfer<W>, W> Transfer<W> for &mut T {
 /// Blocking write
 pub trait Write<W> {
     /// Error type
-    type Error: core::fmt::Debug;
+    type Error: crate::spi::Error;
 
     /// Writes `words` to the slave, ignoring all the incoming words
     fn write(&mut self, words: &[W]) -> Result<(), Self::Error>;
@@ -43,7 +43,7 @@ impl<T: Write<W>, W> Write<W> for &mut T {
 /// Blocking write (iterator version)
 pub trait WriteIter<W> {
     /// Error type
-    type Error: core::fmt::Debug;
+    type Error: crate::spi::Error;
 
     /// Writes `words` to the slave, ignoring all the incoming words
     fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
@@ -77,7 +77,7 @@ pub enum Operation<'a, W: 'static> {
 /// as part of a single SPI transaction
 pub trait Transactional<W: 'static> {
     /// Associated error type
-    type Error: core::fmt::Debug;
+    type Error: crate::spi::Error;
 
     /// Execute the provided transactions
     fn exec<'a>(&mut self, operations: &mut [Operation<'a, W>]) -> Result<(), Self::Error>;

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -53,3 +53,63 @@ pub const MODE_3: Mode = Mode {
     polarity: Polarity::IdleHigh,
     phase: Phase::CaptureOnSecondTransition,
 };
+
+/// SPI error
+pub trait Error: core::fmt::Debug {
+    /// Convert error to a generic SPI error kind
+    ///
+    /// By using this method, SPI errors freely defined by HAL implementations
+    /// can be converted to a set of generic SPI errors upon which generic
+    /// code can act.
+    fn kind(&self) -> ErrorKind;
+}
+
+/// SPI error kind
+///
+/// This represents a common set of SPI operation errors. HAL implementations are
+/// free to define more specific or additional error types. However, by providing
+/// a mapping to these common SPI errors, generic code can still react to them.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// An unspecific bus error occurred
+    Bus,
+    /// The peripheral receive buffer was overrun
+    Overrun,
+    /// Multiple devices on the SPI bus are trying across each other, e.g. in a multi-master setup
+    ModeFault,
+    /// CRC does not match the received data
+    Crc,
+    /// Received data does not conform to the peripheral configuration
+    FrameFormat,
+    /// A different error occurred. The original error may contain more information.
+    Other,
+}
+
+impl Error for ErrorKind {
+    fn kind(&self) -> ErrorKind {
+        *self
+    }
+}
+
+impl core::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Bus => write!(f, "An unspecific bus error occurred"),
+            Self::Overrun => write!(f, "The peripheral receive buffer was overrun"),
+            Self::ModeFault => write!(
+                f,
+                "Multiple devices on the SPI bus are trying across each other"
+            ),
+            Self::Crc => write!(f, "CRC does not match the received data"),
+            Self::FrameFormat => write!(
+                f,
+                "Received data does not conform to the peripheral configuration"
+            ),
+            Self::Other => write!(
+                f,
+                "A different error occurred. The original error may contain more information"
+            ),
+        }
+    }
+}

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -76,8 +76,6 @@ pub enum ErrorKind {
     Overrun,
     /// Multiple devices on the SPI bus are trying to drive the slave select pin, e.g. in a multi-master setup
     ModeFault,
-    /// CRC does not match the received data
-    Crc,
     /// Received data does not conform to the peripheral configuration
     FrameFormat,
     /// A different error occurred. The original error may contain more information.
@@ -98,7 +96,6 @@ impl core::fmt::Display for ErrorKind {
                 f,
                 "Multiple devices on the SPI bus are trying to drive the slave select pin"
             ),
-            Self::Crc => write!(f, "CRC does not match the received data"),
             Self::FrameFormat => write!(
                 f,
                 "Received data does not conform to the peripheral configuration"

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -74,7 +74,7 @@ pub trait Error: core::fmt::Debug {
 pub enum ErrorKind {
     /// The peripheral receive buffer was overrun
     Overrun,
-    /// Multiple devices on the SPI bus are trying across each other, e.g. in a multi-master setup
+    /// Multiple devices on the SPI bus are trying to drive the slave select pin, e.g. in a multi-master setup
     ModeFault,
     /// CRC does not match the received data
     Crc,
@@ -96,7 +96,7 @@ impl core::fmt::Display for ErrorKind {
             Self::Overrun => write!(f, "The peripheral receive buffer was overrun"),
             Self::ModeFault => write!(
                 f,
-                "Multiple devices on the SPI bus are trying across each other"
+                "Multiple devices on the SPI bus are trying to drive the slave select pin"
             ),
             Self::Crc => write!(f, "CRC does not match the received data"),
             Self::FrameFormat => write!(

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -72,8 +72,6 @@ pub trait Error: core::fmt::Debug {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[non_exhaustive]
 pub enum ErrorKind {
-    /// An unspecific bus error occurred
-    Bus,
     /// The peripheral receive buffer was overrun
     Overrun,
     /// Multiple devices on the SPI bus are trying across each other, e.g. in a multi-master setup
@@ -95,7 +93,6 @@ impl Error for ErrorKind {
 impl core::fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::Bus => write!(f, "An unspecific bus error occurred"),
             Self::Overrun => write!(f, "The peripheral receive buffer was overrun"),
             Self::ModeFault => write!(
                 f,

--- a/src/spi/nb.rs
+++ b/src/spi/nb.rs
@@ -18,7 +18,7 @@
 /// `Word` types to allow operation in both modes.
 pub trait FullDuplex<Word> {
     /// An enumeration of SPI errors
-    type Error: core::fmt::Debug;
+    type Error: crate::spi::Error;
 
     /// Reads the word stored in the shift register
     ///


### PR DESCRIPTION
There has been a lengthy discussion about this in #229.
This implements proposal 3 by @TeXitoi which was the latest for I2C, SPI and Serial interfaces.
See [here for the analysis](https://github.com/rust-embedded/embedded-hal/issues/229#issuecomment-701258313)
I included a minimal number of variants for each protocol, mostly borrowed from `embedded-error`. 

This raises the MSRV to Rust 1.40.0 as well in order to mark the `ErrorKind`s as `#[non_exhaustive]` so that adding a new variant is not a breaking change.
I am also fine with _not_ marking the `ErrorKind`s as `#[non_exhaustive]`.

Closes #229