### PR TITLE
Reexport definitions from SPI in blocking SPI module

### DIFF
--- a/src/blocking/spi.rs
+++ b/src/blocking/spi.rs
@@ -1,5 +1,7 @@
 //! Blocking SPI API
 
+pub use crate::nb::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+
 /// Blocking transfer
 pub trait Transfer<W> {
     /// Error type


### PR DESCRIPTION
It makes no sense to offer these only on the `nb` module.
I am also thinking about turning the modules inside out as proposed in the chat room.