### PR TITLE
Fix no_run typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 //!
 //! [`stm32f1`]: https://crates.io/crates/stm32f1
 //!
-//! ```not_run
+//! ```no_run
 //! // crate: stm32f1xx-hal
 //! // An implementation of the `embedded-hal` traits for STM32F1xx microcontrollers
 //!


### PR DESCRIPTION
This typo lead to this example:

https://docs.rs/embedded-hal/1.0.0-alpha.4/embedded_hal/index.html#suggested-implementation

not being highlighted correctly.