### PR TITLE
Add Debug to all spi mode types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added `IoPin` trait for pins that can change between being inputs or outputs
   dynamically.
+- Added `Debug` to all spi mode types.
 
 ### Changed
 - Swap PWM channel arguments to references

--- a/src/nb/spi.rs
+++ b/src/nb/spi.rs
@@ -31,7 +31,7 @@ pub trait FullDuplex<Word> {
 }
 
 /// Clock polarity
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Polarity {
     /// Clock signal low when idle
     IdleLow,
@@ -40,7 +40,7 @@ pub enum Polarity {
 }
 
 /// Clock phase
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Phase {
     /// Data in "captured" on the first clock transition
     CaptureOnFirstTransition,
@@ -49,7 +49,7 @@ pub enum Phase {
 }
 
 /// SPI mode
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Mode {
     /// Clock polarity
     pub polarity: Polarity,


### PR DESCRIPTION
I've noticed that these were missing, and I see no reason why to not implement `Debug`.