### PR TITLE
Add blanket impls for references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `IoPin` trait for pins that can change between being inputs or outputs
   dynamically.
 - Added `Debug` to all spi mode types.
+- Added blanket impls for references.
 
 ### Changed
 - Swap PWM channel arguments to references

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `IoPin` trait for pins that can change between being inputs or outputs
   dynamically.
 - Added `Debug` to all spi mode types.
-- Added blanket impls for references.
+- Add impls of all traits for references (`&T` or `&mut T` depending on the trait) when `T` implements the trait.
 
 ### Changed
 - Swap PWM channel arguments to references

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -51,6 +51,14 @@ pub mod nb {
         fn channel(&self) -> Self::ID;
     }
 
+    impl<T: Channel<ADC>, ADC> Channel<ADC> for &T {
+        type ID = T::ID;
+
+        fn channel(&self) -> Self::ID {
+            (*self).channel()
+        }
+    }
+
     /// ADCs that sample on single channels per request, and do so at the time of the request.
     ///
     /// This trait is the interface to an ADC that is configured to read a specific channel at the time
@@ -91,5 +99,16 @@ pub mod nb {
         /// This method takes a `Pin` reference, as it is expected that the ADC will be able to sample
         /// whatever channel underlies the pin.
         fn read(&mut self, pin: &mut Pin) -> nb::Result<Word, Self::Error>;
+    }
+
+    impl<T, ADC, Word, Pin: Channel<ADC>> OneShot<ADC, Word, Pin> for &mut T
+    where
+        T: OneShot<ADC, Word, Pin>,
+    {
+        type Error = T::Error;
+
+        fn read(&mut self, pin: &mut Pin) -> nb::Result<Word, Self::Error> {
+            (*self).read(pin)
+        }
     }
 }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -55,7 +55,7 @@ pub mod nb {
         type ID = T::ID;
 
         fn channel(&self) -> Self::ID {
-            (*self).channel()
+            T::channel(self)
         }
     }
 
@@ -108,7 +108,7 @@ pub mod nb {
         type Error = T::Error;
 
         fn read(&mut self, pin: &mut Pin) -> nb::Result<Word, Self::Error> {
-            (*self).read(pin)
+            T::read(self, pin)
         }
     }
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -105,26 +105,26 @@ pub mod nb {
         type Capture = T::Capture;
 
         fn capture(&mut self, channel: Self::Channel) -> nb::Result<Self::Capture, Self::Error> {
-            (*self).capture(channel)
+            T::capture(self, channel)
         }
 
         fn disable(&mut self, channel: Self::Channel) -> Result<(), Self::Error> {
-            (*self).disable(channel)
+            T::disable(self, channel)
         }
 
         fn enable(&mut self, channel: Self::Channel) -> Result<(), Self::Error> {
-            (*self).enable(channel)
+            T::enable(self, channel)
         }
 
         fn get_resolution(&self) -> Result<Self::Time, Self::Error> {
-            (**self).get_resolution()
+            T::get_resolution(self)
         }
 
         fn set_resolution<R>(&mut self, resolution: R) -> Result<(), Self::Error>
         where
             R: Into<Self::Time>,
         {
-            (*self).set_resolution(resolution)
+            T::set_resolution(self, resolution)
         }
     }
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -94,4 +94,37 @@ pub mod nb {
         where
             R: Into<Self::Time>;
     }
+
+    impl<T: Capture> Capture for &mut T {
+        type Error = T::Error;
+
+        type Channel = T::Channel;
+
+        type Time = T::Time;
+
+        type Capture = T::Capture;
+
+        fn capture(&mut self, channel: Self::Channel) -> nb::Result<Self::Capture, Self::Error> {
+            (*self).capture(channel)
+        }
+
+        fn disable(&mut self, channel: Self::Channel) -> Result<(), Self::Error> {
+            (*self).disable(channel)
+        }
+
+        fn enable(&mut self, channel: Self::Channel) -> Result<(), Self::Error> {
+            (*self).enable(channel)
+        }
+
+        fn get_resolution(&self) -> Result<Self::Time, Self::Error> {
+            (**self).get_resolution()
+        }
+
+        fn set_resolution<R>(&mut self, resolution: R) -> Result<(), Self::Error>
+        where
+            R: Into<Self::Time>,
+        {
+            (*self).set_resolution(resolution)
+        }
+    }
 }

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -21,6 +21,14 @@ pub mod blocking {
         fn delay_ms(&mut self, ms: UXX) -> Result<(), Self::Error>;
     }
 
+    impl<UXX, T: DelayMs<UXX>> DelayMs<UXX> for &mut T {
+        type Error = T::Error;
+
+        fn delay_ms(&mut self, ms: UXX) -> Result<(), Self::Error> {
+            (*self).delay_ms(ms)
+        }
+    }
+
     /// Microsecond delay
     ///
     /// `UXX` denotes the range type of the delay time. `UXX` can be `u8`, `u16`, etc. A single type can
@@ -31,5 +39,13 @@ pub mod blocking {
 
         /// Pauses execution for `us` microseconds
         fn delay_us(&mut self, us: UXX) -> Result<(), Self::Error>;
+    }
+
+    impl<UXX, T: DelayUs<UXX>> DelayUs<UXX> for &mut T {
+        type Error = T::Error;
+
+        fn delay_us(&mut self, us: UXX) -> Result<(), Self::Error> {
+            (*self).delay_us(us)
+        }
     }
 }

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -25,7 +25,7 @@ pub mod blocking {
         type Error = T::Error;
 
         fn delay_ms(&mut self, ms: UXX) -> Result<(), Self::Error> {
-            (*self).delay_ms(ms)
+            T::delay_ms(self, ms)
         }
     }
 
@@ -45,7 +45,7 @@ pub mod blocking {
         type Error = T::Error;
 
         fn delay_us(&mut self, us: UXX) -> Result<(), Self::Error> {
-            (*self).delay_us(us)
+            T::delay_us(self, us)
         }
     }
 }

--- a/src/digital.rs
+++ b/src/digital.rs
@@ -81,15 +81,15 @@ pub mod blocking {
         type Error = T::Error;
 
         fn set_low(&mut self) -> Result<(), Self::Error> {
-            (*self).set_low()
+            T::set_low(self)
         }
 
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            (*self).set_high()
+            T::set_high(self)
         }
 
         fn set_state(&mut self, state: PinState) -> Result<(), Self::Error> {
-            (*self).set_state(state)
+            T::set_state(self, state)
         }
     }
 
@@ -108,11 +108,11 @@ pub mod blocking {
 
     impl<T: StatefulOutputPin> StatefulOutputPin for &mut T {
         fn is_set_high(&self) -> Result<bool, Self::Error> {
-            (**self).is_set_high()
+            T::is_set_high(self)
         }
 
         fn is_set_low(&self) -> Result<bool, Self::Error> {
-            (**self).is_set_low()
+            T::is_set_low(self)
         }
     }
 
@@ -134,7 +134,7 @@ pub mod blocking {
         type Error = T::Error;
 
         fn toggle(&mut self) -> Result<(), Self::Error> {
-            (*self).toggle()
+            T::toggle(self)
         }
     }
 
@@ -154,11 +154,11 @@ pub mod blocking {
         type Error = T::Error;
 
         fn is_high(&self) -> Result<bool, Self::Error> {
-            (*self).is_high()
+            T::is_high(self)
         }
 
         fn is_low(&self) -> Result<bool, Self::Error> {
-            (*self).is_low()
+            T::is_low(self)
         }
     }
 

--- a/src/digital.rs
+++ b/src/digital.rs
@@ -77,6 +77,22 @@ pub mod blocking {
         }
     }
 
+    impl<T: OutputPin> OutputPin for &mut T {
+        type Error = T::Error;
+
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            (*self).set_low()
+        }
+
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            (*self).set_high()
+        }
+
+        fn set_state(&mut self, state: PinState) -> Result<(), Self::Error> {
+            (*self).set_state(state)
+        }
+    }
+
     /// Push-pull output pin that can read its output state
     pub trait StatefulOutputPin: OutputPin {
         /// Is the pin in drive high mode?
@@ -88,6 +104,16 @@ pub mod blocking {
         ///
         /// *NOTE* this does *not* read the electrical state of the pin
         fn is_set_low(&self) -> Result<bool, Self::Error>;
+    }
+
+    impl<T: StatefulOutputPin> StatefulOutputPin for &mut T {
+        fn is_set_high(&self) -> Result<bool, Self::Error> {
+            (**self).is_set_high()
+        }
+
+        fn is_set_low(&self) -> Result<bool, Self::Error> {
+            (**self).is_set_low()
+        }
     }
 
     /// Output pin that can be toggled
@@ -104,6 +130,14 @@ pub mod blocking {
         fn toggle(&mut self) -> Result<(), Self::Error>;
     }
 
+    impl<T: ToggleableOutputPin> ToggleableOutputPin for &mut T {
+        type Error = T::Error;
+
+        fn toggle(&mut self) -> Result<(), Self::Error> {
+            (*self).toggle()
+        }
+    }
+
     /// Single digital input pin
     pub trait InputPin {
         /// Error type
@@ -114,6 +148,18 @@ pub mod blocking {
 
         /// Is the input pin low?
         fn is_low(&self) -> Result<bool, Self::Error>;
+    }
+
+    impl<T: InputPin> InputPin for &T {
+        type Error = T::Error;
+
+        fn is_high(&self) -> Result<bool, Self::Error> {
+            (*self).is_high()
+        }
+
+        fn is_low(&self) -> Result<bool, Self::Error> {
+            (*self).is_low()
+        }
     }
 
     /// Single pin that can switch from input to output mode, and vice-versa.

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -151,7 +151,7 @@ pub mod blocking {
         type Error = T::Error;
 
         fn read(&mut self, address: A, buffer: &mut [u8]) -> Result<(), Self::Error> {
-            (*self).read(address, buffer)
+            T::read(self, address, buffer)
         }
     }
 
@@ -183,7 +183,7 @@ pub mod blocking {
         type Error = T::Error;
 
         fn write(&mut self, address: A, bytes: &[u8]) -> Result<(), Self::Error> {
-            (*self).write(address, bytes)
+            T::write(self, address, bytes)
         }
     }
 
@@ -209,7 +209,7 @@ pub mod blocking {
         where
             B: IntoIterator<Item = u8>,
         {
-            (*self).write_iter(address, bytes)
+            T::write_iter(self, address, bytes)
         }
     }
 
@@ -257,7 +257,7 @@ pub mod blocking {
             bytes: &[u8],
             buffer: &mut [u8],
         ) -> Result<(), Self::Error> {
-            (*self).write_read(address, bytes, buffer)
+            T::write_read(self, address, bytes, buffer)
         }
     }
 
@@ -294,7 +294,7 @@ pub mod blocking {
         where
             B: IntoIterator<Item = u8>,
         {
-            (*self).write_iter_read(address, bytes, buffer)
+            T::write_iter_read(self, address, bytes, buffer)
         }
     }
 
@@ -344,7 +344,7 @@ pub mod blocking {
             address: A,
             operations: &mut [Operation<'a>],
         ) -> Result<(), Self::Error> {
-            (*self).exec(address, operations)
+            T::exec(self, address, operations)
         }
     }
 
@@ -380,7 +380,7 @@ pub mod blocking {
         where
             O: IntoIterator<Item = Operation<'a>>,
         {
-            (*self).exec_iter(address, operations)
+            T::exec_iter(self, address, operations)
         }
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -147,6 +147,14 @@ pub mod blocking {
         fn read(&mut self, address: A, buffer: &mut [u8]) -> Result<(), Self::Error>;
     }
 
+    impl<A: AddressMode, T: Read<A>> Read<A> for &mut T {
+        type Error = T::Error;
+
+        fn read(&mut self, address: A, buffer: &mut [u8]) -> Result<(), Self::Error> {
+            (*self).read(address, buffer)
+        }
+    }
+
     /// Blocking write
     pub trait Write<A: AddressMode = SevenBitAddress> {
         /// Error type
@@ -171,6 +179,14 @@ pub mod blocking {
         fn write(&mut self, address: A, bytes: &[u8]) -> Result<(), Self::Error>;
     }
 
+    impl<A: AddressMode, T: Write<A>> Write<A> for &mut T {
+        type Error = T::Error;
+
+        fn write(&mut self, address: A, bytes: &[u8]) -> Result<(), Self::Error> {
+            (*self).write(address, bytes)
+        }
+    }
+
     /// Blocking write (iterator version)
     pub trait WriteIter<A: AddressMode = SevenBitAddress> {
         /// Error type
@@ -184,6 +200,17 @@ pub mod blocking {
         fn write_iter<B>(&mut self, address: A, bytes: B) -> Result<(), Self::Error>
         where
             B: IntoIterator<Item = u8>;
+    }
+
+    impl<A: AddressMode, T: WriteIter<A>> WriteIter<A> for &mut T {
+        type Error = T::Error;
+
+        fn write_iter<B>(&mut self, address: A, bytes: B) -> Result<(), Self::Error>
+        where
+            B: IntoIterator<Item = u8>,
+        {
+            (*self).write_iter(address, bytes)
+        }
     }
 
     /// Blocking write + read
@@ -221,6 +248,19 @@ pub mod blocking {
         ) -> Result<(), Self::Error>;
     }
 
+    impl<A: AddressMode, T: WriteRead<A>> WriteRead<A> for &mut T {
+        type Error = T::Error;
+
+        fn write_read(
+            &mut self,
+            address: A,
+            bytes: &[u8],
+            buffer: &mut [u8],
+        ) -> Result<(), Self::Error> {
+            (*self).write_read(address, bytes, buffer)
+        }
+    }
+
     /// Blocking write (iterator version) + read
     pub trait WriteIterRead<A: AddressMode = SevenBitAddress> {
         /// Error type
@@ -240,6 +280,22 @@ pub mod blocking {
         ) -> Result<(), Self::Error>
         where
             B: IntoIterator<Item = u8>;
+    }
+
+    impl<A: AddressMode, T: WriteIterRead<A>> WriteIterRead<A> for &mut T {
+        type Error = T::Error;
+
+        fn write_iter_read<B>(
+            &mut self,
+            address: A,
+            bytes: B,
+            buffer: &mut [u8],
+        ) -> Result<(), Self::Error>
+        where
+            B: IntoIterator<Item = u8>,
+        {
+            (*self).write_iter_read(address, bytes, buffer)
+        }
     }
 
     /// Transactional I2C operation.
@@ -280,6 +336,18 @@ pub mod blocking {
         ) -> Result<(), Self::Error>;
     }
 
+    impl<A: AddressMode, T: Transactional<A>> Transactional<A> for &mut T {
+        type Error = T::Error;
+
+        fn exec<'a>(
+            &mut self,
+            address: A,
+            operations: &mut [Operation<'a>],
+        ) -> Result<(), Self::Error> {
+            (*self).exec(address, operations)
+        }
+    }
+
     /// Transactional I2C interface (iterator version).
     ///
     /// This allows combining operation within an I2C transaction.
@@ -303,5 +371,16 @@ pub mod blocking {
         fn exec_iter<'a, O>(&mut self, address: A, operations: O) -> Result<(), Self::Error>
         where
             O: IntoIterator<Item = Operation<'a>>;
+    }
+
+    impl<A: AddressMode, T: TransactionalIter<A>> TransactionalIter<A> for &mut T {
+        type Error = T::Error;
+
+        fn exec_iter<'a, O>(&mut self, address: A, operations: O) -> Result<(), Self::Error>
+        where
+            O: IntoIterator<Item = Operation<'a>>,
+        {
+            (*self).exec_iter(address, operations)
+        }
     }
 }

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -112,23 +112,23 @@ pub mod blocking {
         type Duty = T::Duty;
 
         fn disable(&mut self, channel: &Self::Channel) -> Result<(), Self::Error> {
-            (*self).disable(channel)
+            T::disable(self, channel)
         }
 
         fn enable(&mut self, channel: &Self::Channel) -> Result<(), Self::Error> {
-            (*self).enable(channel)
+            T::enable(self, channel)
         }
 
         fn get_period(&self) -> Result<Self::Time, Self::Error> {
-            (**self).get_period()
+            T::get_period(self)
         }
 
         fn get_duty(&self, channel: &Self::Channel) -> Result<Self::Duty, Self::Error> {
-            (**self).get_duty(channel)
+            T::get_duty(self, channel)
         }
 
         fn get_max_duty(&self) -> Result<Self::Duty, Self::Error> {
-            (**self).get_max_duty()
+            T::get_max_duty(self)
         }
 
         fn set_duty(
@@ -136,14 +136,14 @@ pub mod blocking {
             channel: &Self::Channel,
             duty: Self::Duty,
         ) -> Result<(), Self::Error> {
-            (*self).set_duty(channel, duty)
+            T::set_duty(self, channel, duty)
         }
 
         fn set_period<P>(&mut self, period: P) -> Result<(), Self::Error>
         where
             P: Into<Self::Time>,
         {
-            (*self).set_period(period)
+            T::set_period(self, period)
         }
     }
 
@@ -185,23 +185,23 @@ pub mod blocking {
         type Duty = T::Duty;
 
         fn disable(&mut self) -> Result<(), Self::Error> {
-            (*self).disable()
+            T::disable(self)
         }
 
         fn enable(&mut self) -> Result<(), Self::Error> {
-            (*self).enable()
+            T::enable(self)
         }
 
         fn get_duty(&self) -> Result<Self::Duty, Self::Error> {
-            (**self).get_duty()
+            T::get_duty(self)
         }
 
         fn get_max_duty(&self) -> Result<Self::Duty, Self::Error> {
-            (**self).get_max_duty()
+            T::get_max_duty(self)
         }
 
         fn set_duty(&mut self, duty: Self::Duty) -> Result<(), Self::Error> {
-            (*self).set_duty(duty)
+            T::set_duty(self, duty)
         }
     }
 }

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -102,6 +102,51 @@ pub mod blocking {
             P: Into<Self::Time>;
     }
 
+    impl<T: Pwm> Pwm for &mut T {
+        type Error = T::Error;
+
+        type Channel = T::Channel;
+
+        type Time = T::Time;
+
+        type Duty = T::Duty;
+
+        fn disable(&mut self, channel: &Self::Channel) -> Result<(), Self::Error> {
+            (*self).disable(channel)
+        }
+
+        fn enable(&mut self, channel: &Self::Channel) -> Result<(), Self::Error> {
+            (*self).enable(channel)
+        }
+
+        fn get_period(&self) -> Result<Self::Time, Self::Error> {
+            (**self).get_period()
+        }
+
+        fn get_duty(&self, channel: &Self::Channel) -> Result<Self::Duty, Self::Error> {
+            (**self).get_duty(channel)
+        }
+
+        fn get_max_duty(&self) -> Result<Self::Duty, Self::Error> {
+            (**self).get_max_duty()
+        }
+
+        fn set_duty(
+            &mut self,
+            channel: &Self::Channel,
+            duty: Self::Duty,
+        ) -> Result<(), Self::Error> {
+            (*self).set_duty(channel, duty)
+        }
+
+        fn set_period<P>(&mut self, period: P) -> Result<(), Self::Error>
+        where
+            P: Into<Self::Time>,
+        {
+            (*self).set_period(period)
+        }
+    }
+
     /// A single PWM channel / pin
     ///
     /// See `Pwm` for details
@@ -132,5 +177,31 @@ pub mod blocking {
 
         /// Sets a new duty cycle
         fn set_duty(&mut self, duty: Self::Duty) -> Result<(), Self::Error>;
+    }
+
+    impl<T: PwmPin> PwmPin for &mut T {
+        type Error = T::Error;
+
+        type Duty = T::Duty;
+
+        fn disable(&mut self) -> Result<(), Self::Error> {
+            (*self).disable()
+        }
+
+        fn enable(&mut self) -> Result<(), Self::Error> {
+            (*self).enable()
+        }
+
+        fn get_duty(&self) -> Result<Self::Duty, Self::Error> {
+            (**self).get_duty()
+        }
+
+        fn get_max_duty(&self) -> Result<Self::Duty, Self::Error> {
+            (**self).get_max_duty()
+        }
+
+        fn set_duty(&mut self, duty: Self::Duty) -> Result<(), Self::Error> {
+            (*self).set_duty(duty)
+        }
     }
 }

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -88,11 +88,11 @@ pub mod blocking {
         type Count = T::Count;
 
         fn count(&self) -> Result<Self::Count, Self::Error> {
-            (*self).count()
+            T::count(self)
         }
 
         fn direction(&self) -> Result<Direction, Self::Error> {
-            (*self).direction()
+            T::direction(self)
         }
     }
 }

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -81,4 +81,18 @@ pub mod blocking {
         /// Returns the count direction
         fn direction(&self) -> Result<Direction, Self::Error>;
     }
+
+    impl<T: Qei> Qei for &T {
+        type Error = T::Error;
+
+        type Count = T::Count;
+
+        fn count(&self) -> Result<Self::Count, Self::Error> {
+            (*self).count()
+        }
+
+        fn direction(&self) -> Result<Direction, Self::Error> {
+            (*self).direction()
+        }
+    }
 }

--- a/src/serial/blocking.rs
+++ b/src/serial/blocking.rs
@@ -22,3 +22,15 @@ pub trait Write<Word> {
     /// Block until the serial interface has sent all buffered words
     fn flush(&mut self) -> Result<(), Self::Error>;
 }
+
+impl<T: Write<Word>, Word> Write<Word> for &mut T {
+    type Error = T::Error;
+
+    fn write(&mut self, buffer: &[Word]) -> Result<(), Self::Error> {
+        (*self).write(buffer)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        (*self).flush()
+    }
+}

--- a/src/serial/blocking.rs
+++ b/src/serial/blocking.rs
@@ -27,10 +27,10 @@ impl<T: Write<Word>, Word> Write<Word> for &mut T {
     type Error = T::Error;
 
     fn write(&mut self, buffer: &[Word]) -> Result<(), Self::Error> {
-        (*self).write(buffer)
+        T::write(self, buffer)
     }
 
     fn flush(&mut self) -> Result<(), Self::Error> {
-        (*self).flush()
+        T::flush(self)
     }
 }

--- a/src/serial/nb.rs
+++ b/src/serial/nb.rs
@@ -12,6 +12,14 @@ pub trait Read<Word> {
     fn read(&mut self) -> nb::Result<Word, Self::Error>;
 }
 
+impl<T: Read<Word>, Word> Read<Word> for &mut T {
+    type Error = T::Error;
+
+    fn read(&mut self) -> nb::Result<Word, Self::Error> {
+        (*self).read()
+    }
+}
+
 /// Write half of a serial interface
 pub trait Write<Word> {
     /// Write error
@@ -22,4 +30,16 @@ pub trait Write<Word> {
 
     /// Ensures that none of the previously written words are still buffered
     fn flush(&mut self) -> nb::Result<(), Self::Error>;
+}
+
+impl<T: Write<Word>, Word> Write<Word> for &mut T {
+    type Error = T::Error;
+
+    fn write(&mut self, word: Word) -> nb::Result<(), Self::Error> {
+        (*self).write(word)
+    }
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        (*self).flush()
+    }
 }

--- a/src/serial/nb.rs
+++ b/src/serial/nb.rs
@@ -16,7 +16,7 @@ impl<T: Read<Word>, Word> Read<Word> for &mut T {
     type Error = T::Error;
 
     fn read(&mut self) -> nb::Result<Word, Self::Error> {
-        (*self).read()
+        T::read(self)
     }
 }
 
@@ -36,10 +36,10 @@ impl<T: Write<Word>, Word> Write<Word> for &mut T {
     type Error = T::Error;
 
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error> {
-        (*self).write(word)
+        T::write(self, word)
     }
 
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
-        (*self).flush()
+        T::flush(self)
     }
 }

--- a/src/spi/blocking.rs
+++ b/src/spi/blocking.rs
@@ -15,6 +15,14 @@ pub trait Transfer<W> {
     fn transfer(&mut self, words: &mut [W]) -> Result<(), Self::Error>;
 }
 
+impl<T: Transfer<W>, W> Transfer<W> for &mut T {
+    type Error = T::Error;
+
+    fn transfer(&mut self, words: &mut [W]) -> Result<(), Self::Error> {
+        (*self).transfer(words)
+    }
+}
+
 /// Blocking write
 pub trait Write<W> {
     /// Error type
@@ -22,6 +30,14 @@ pub trait Write<W> {
 
     /// Writes `words` to the slave, ignoring all the incoming words
     fn write(&mut self, words: &[W]) -> Result<(), Self::Error>;
+}
+
+impl<T: Write<W>, W> Write<W> for &mut T {
+    type Error = T::Error;
+
+    fn write(&mut self, words: &[W]) -> Result<(), Self::Error> {
+        (*self).write(words)
+    }
 }
 
 /// Blocking write (iterator version)
@@ -33,6 +49,17 @@ pub trait WriteIter<W> {
     fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
     where
         WI: IntoIterator<Item = W>;
+}
+
+impl<T: WriteIter<W>, W> WriteIter<W> for &mut T {
+    type Error = T::Error;
+
+    fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
+    where
+        WI: IntoIterator<Item = W>,
+    {
+        (*self).write_iter(words)
+    }
 }
 
 /// Operation for transactional SPI trait
@@ -54,4 +81,12 @@ pub trait Transactional<W: 'static> {
 
     /// Execute the provided transactions
     fn exec<'a>(&mut self, operations: &mut [Operation<'a, W>]) -> Result<(), Self::Error>;
+}
+
+impl<T: Transactional<W>, W: 'static> Transactional<W> for &mut T {
+    type Error = T::Error;
+
+    fn exec<'a>(&mut self, operations: &mut [Operation<'a, W>]) -> Result<(), Self::Error> {
+        (*self).exec(operations)
+    }
 }

--- a/src/spi/blocking.rs
+++ b/src/spi/blocking.rs
@@ -19,7 +19,7 @@ impl<T: Transfer<W>, W> Transfer<W> for &mut T {
     type Error = T::Error;
 
     fn transfer(&mut self, words: &mut [W]) -> Result<(), Self::Error> {
-        (*self).transfer(words)
+        T::transfer(self, words)
     }
 }
 
@@ -36,7 +36,7 @@ impl<T: Write<W>, W> Write<W> for &mut T {
     type Error = T::Error;
 
     fn write(&mut self, words: &[W]) -> Result<(), Self::Error> {
-        (*self).write(words)
+        T::write(self, words)
     }
 }
 
@@ -58,7 +58,7 @@ impl<T: WriteIter<W>, W> WriteIter<W> for &mut T {
     where
         WI: IntoIterator<Item = W>,
     {
-        (*self).write_iter(words)
+        T::write_iter(self, words)
     }
 }
 
@@ -87,6 +87,6 @@ impl<T: Transactional<W>, W: 'static> Transactional<W> for &mut T {
     type Error = T::Error;
 
     fn exec<'a>(&mut self, operations: &mut [Operation<'a, W>]) -> Result<(), Self::Error> {
-        (*self).exec(operations)
+        T::exec(self, operations)
     }
 }

--- a/src/spi/nb.rs
+++ b/src/spi/nb.rs
@@ -29,3 +29,15 @@ pub trait FullDuplex<Word> {
     /// Writes a word to the slave
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error>;
 }
+
+impl<T: FullDuplex<Word>, Word> FullDuplex<Word> for &mut T {
+    type Error = T::Error;
+
+    fn read(&mut self) -> nb::Result<Word, Self::Error> {
+        (*self).read()
+    }
+
+    fn write(&mut self, word: Word) -> nb::Result<(), Self::Error> {
+        (*self).write(word)
+    }
+}

--- a/src/spi/nb.rs
+++ b/src/spi/nb.rs
@@ -34,10 +34,10 @@ impl<T: FullDuplex<Word>, Word> FullDuplex<Word> for &mut T {
     type Error = T::Error;
 
     fn read(&mut self) -> nb::Result<Word, Self::Error> {
-        (*self).read()
+        T::read(self)
     }
 
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error> {
-        (*self).write(word)
+        T::write(self, word)
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -94,11 +94,11 @@ pub mod nb {
         where
             TIME: Into<Self::Time>,
         {
-            (*self).start(count)
+            T::start(self, count)
         }
 
         fn wait(&mut self) -> nb::Result<(), Self::Error> {
-            (*self).wait()
+            T::wait(self)
         }
     }
 
@@ -115,7 +115,7 @@ pub mod nb {
 
     impl<T: Cancel> Cancel for &mut T {
         fn cancel(&mut self) -> Result<(), Self::Error> {
-            (*self).cancel()
+            T::cancel(self)
         }
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -85,6 +85,23 @@ pub mod nb {
         fn wait(&mut self) -> nb::Result<(), Self::Error>;
     }
 
+    impl<T: CountDown> CountDown for &mut T {
+        type Error = T::Error;
+
+        type Time = T::Time;
+
+        fn start<TIME>(&mut self, count: TIME) -> Result<(), Self::Error>
+        where
+            TIME: Into<Self::Time>,
+        {
+            (*self).start(count)
+        }
+
+        fn wait(&mut self) -> nb::Result<(), Self::Error> {
+            (*self).wait()
+        }
+    }
+
     /// Trait for cancelable countdowns.
     pub trait Cancel: CountDown {
         /// Tries to cancel this countdown.
@@ -94,5 +111,11 @@ pub mod nb {
         /// An error will be returned if the countdown has already been canceled or was never started.
         /// An error is also returned if the countdown is not `Periodic` and has already expired.
         fn cancel(&mut self) -> Result<(), Self::Error>;
+    }
+
+    impl<T: Cancel> Cancel for &mut T {
+        fn cancel(&mut self) -> Result<(), Self::Error> {
+            (*self).cancel()
+        }
     }
 }

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -16,6 +16,14 @@ pub mod blocking {
         fn feed(&mut self) -> Result<(), Self::Error>;
     }
 
+    impl<T: Watchdog> Watchdog for &mut T {
+        type Error = T::Error;
+
+        fn feed(&mut self) -> Result<(), Self::Error> {
+            (*self).feed()
+        }
+    }
+
     /// Enables A watchdog timer to reset the processor if software is frozen or
     /// stalled.
     pub trait Enable {

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -20,7 +20,7 @@ pub mod blocking {
         type Error = T::Error;
 
         fn feed(&mut self) -> Result<(), Self::Error> {
-            (*self).feed()
+            T::feed(self)
         }
     }
 


### PR DESCRIPTION
I would prefer to use a proc-macro like [auto-impl](https://crates.io/crates/auto_impl), but that doesn't support no_std yet. (see auto-impl-rs/auto_impl#73)