### PR TITLE
Prepare 1.0.0-alpha.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+
+## [v1.0.0-alpha.5] - 2021-09-11
+
+*** This is (also) an alpha release with breaking changes (sorry) ***
+
 ### Added
 - Added `IoPin` trait for pins that can change between being inputs or outputs
   dynamically.
@@ -167,7 +172,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.4...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.5...HEAD
+[v1.0.0-alpha.5]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.4...v1.0.0-alpha.5
 [v1.0.0-alpha.4]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.3...v1.0.0-alpha.4
 [v1.0.0-alpha.3]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.2...v1.0.0-alpha.3
 [v1.0.0-alpha.2]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.1...v1.0.0-alpha.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "1.0.0-alpha.4" # remember to update html_root_url
+version = "1.0.0-alpha.5" # remember to update html_root_url
 
 [dependencies]
 nb = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,7 +411,7 @@
 //! # fn main() {}
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/embedded-hal/1.0.0-alpha.4")]
+#![doc(html_root_url = "https://docs.rs/embedded-hal/1.0.0-alpha.5")]
 #![deny(missing_docs)]
 #![no_std]
 


### PR DESCRIPTION
I think it would be good to make a new alpha release after the latest major changes.