### PR TITLE
Simplify blocking Delay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed the various `Default` marker traits.
 - Removed `&[W]` returned slice in `spi::blocking::Transfer`.
 - Require all associated error types to implement `core::fmt::Debug`.
+- Simplified delay traits: removed `DelayMs`, changed `DelayUs` to use u32 instead of generic width integers.
 
 ### Removed
 - Removed random number generation (`rng`) traits in favor of [rand_core](https://crates.io/crates/rand_core).

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -9,27 +9,12 @@
 
 /// Blocking delay traits
 pub mod blocking {
-    /// Millisecond delay
-    ///
-    /// `UXX` denotes the range type of the delay time. `UXX` can be `u8`, `u16`, etc. A single type can
-    /// implement this trait for different types of `UXX`.
-    pub trait DelayMs<UXX> {
-        /// Enumeration of `DelayMs` errors
-        type Error: core::fmt::Debug;
-
-        /// Pauses execution for `ms` milliseconds
-        fn delay_ms(&mut self, ms: UXX) -> Result<(), Self::Error>;
-    }
-
-    /// Microsecond delay
-    ///
-    /// `UXX` denotes the range type of the delay time. `UXX` can be `u8`, `u16`, etc. A single type can
-    /// implement this trait for different types of `UXX`.
-    pub trait DelayUs<UXX> {
-        /// Enumeration of `DelayMs` errors
+    /// Simple microsecond delay
+    pub trait DelayUs {
+        /// Enumeration of `DelayUs` errors
         type Error: core::fmt::Debug;
 
         /// Pauses execution for `us` microseconds
-        fn delay_us(&mut self, us: UXX) -> Result<(), Self::Error>;
+        fn delay_us(&mut self, us: u32) -> Result<(), Self::Error>;
     }
 }


### PR DESCRIPTION
Quick summary of discussions in #177 and in [today's REWG meeting](https://matrix.to/#/!BHcierreUuwCMxVqOf:matrix.org/$YCEXZwpQiBjrhmrFVxGTUNlbzr2woWz1buzXNi1foAo?via=matrix.org&via=psion.agg.io&via=mozilla.org):

- We need a hardawre-agnostic, efficient way of representing time durations for use in the e-h traits, but that's probably far away.
- The current DelayMs/DelayUs traits are not the answer, they require duplicating impls for each unit and each integer size.
- There's issues where HALs don't implement all DelayMs/DelayUs combinations, causing some drivers to not work with them.
- However, "blocking delay" is an incredibly important and widely used trait, releasing 1.0 without it is not an option.

The compromise found to unblock 1.0 while mitigating the issues is:

- remove DelayMs
- change DelayUs to use u32 instead of generic width integers.

Why:

- Fixes the pain of HALs not implementing all combinations.
- For the most common use cases (blinks, waiting for chips to initialize...) microsecond precision is enough. 
- u32 allows for a max delay of ~1.2h. Such blocking delays should be extremely rare, as the core can do absolutely nothing else during it (unless it uses interrupts, but then you're probably already doing interrupt-based timers).
- The runtime cost of forcing using 32bit is negligible, most HALs are already doing 32bit math on the duration to convert it to clock ticks.

The name `Delay` is reserved for the future trait that will use the new shiny Duration representation, hence `DelayUs` is kept even though there's only one trait.

When the final `Delay` trait is released, we may (or may not if we still think it's handy) deprecate `DelayUs`.