### PR TITLE
I2C NACK error nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   implement these `Error` traits, which implies providing a conversion to a common
   set of error kinds. Generic drivers using these interfaces can then convert the errors
   to this common set to act upon them.
+- The `NoAcknowledgeAddress` and `NoAcknowledgeData` variants of the I2C `Error`
+  trait have been merged into `NoAcknowledge` with a `NoAcknowledgeSource` field
+  to differentiate between the two events. An additional `Unknown` variant is
+  provided in `NoAcknowledgeSource` for devices that can't differentiate between
+  the two events.
 
 ### Removed
 - Removed `DelayMs` in favor of `DelayUs` with `u32` as type for clarity.

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -119,7 +119,8 @@ pub trait Error: core::fmt::Debug {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[non_exhaustive]
 pub enum ErrorKind {
-    /// Bus error occurred. e.g. A START or a STOP condition is detected and is not located after a multiple of 9 SCL clock pulses.
+    /// Bus error occurred. e.g. A START or a STOP condition is detected and is not
+    /// located after a multiple of 9 SCL clock pulses.
     Bus,
     /// The arbitration was lost, e.g. electrical problems with the clock signal
     ArbitrationLoss,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -123,14 +123,31 @@ pub enum ErrorKind {
     Bus,
     /// The arbitration was lost, e.g. electrical problems with the clock signal
     ArbitrationLoss,
-    /// The device did not acknowledge its address. The device may be missing.
-    NoAcknowledgeAddress,
-    /// The device did not acknowled the data. It may not be ready to process requests at the moment.
-    NoAcknowledgeData,
+    /// A bus operation was not acknowledged, e.g. due to the addressed device not
+    /// being available on the bus or the device not being ready to process requests
+    /// at the moment
+    NoAcknowledge(NoAcknowledgeSource),
     /// The peripheral receive buffer was overrun
     Overrun,
     /// A different error occurred. The original error may contain more information.
     Other,
+}
+
+/// I2C no acknowledge error source
+///
+/// In cases where it is possible, a device should indicate if a no acknowledge
+/// response was received to an address versus a no acknowledge to a data byte.
+/// Where it is not possible to differentiate, `Unknown` should be indicated.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum NoAcknowledgeSource {
+    /// The device did not acknowledge its address. The device may be missing.
+    Address,
+    /// The device did not acknowledge the data. It may not be ready to process
+    /// requests at the moment.
+    Data,
+    /// Either the device did not acknowledge its address or the data, but it is
+    /// unknown which.
+    Unknown,
 }
 
 impl Error for ErrorKind {
@@ -144,13 +161,22 @@ impl core::fmt::Display for ErrorKind {
         match self {
             Self::Bus => write!(f, "Bus error occurred"),
             Self::ArbitrationLoss => write!(f, "The arbitration was lost"),
-            Self::NoAcknowledgeAddress => write!(f, "The device did not acknowledge its address"),
-            Self::NoAcknowledgeData => write!(f, "The device did not acknowledge the data"),
+            Self::NoAcknowledge(s) => s.fmt(f),
             Self::Overrun => write!(f, "The peripheral receive buffer was overrun"),
             Self::Other => write!(
                 f,
                 "A different error occurred. The original error may contain more information"
             ),
+        }
+    }
+}
+
+impl core::fmt::Display for NoAcknowledgeSource {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Address => write!(f, "The device did not acknowledge its address"),
+            Self::Data => write!(f, "The device did not acknowledge the data"),
+            Self::Unknown => write!(f, "The device did not acknowledge its address or the data"),
         }
     }
 }


### PR DESCRIPTION
This idea was first proposed [here](https://github.com/rust-embedded/embedded-hal/pull/296#discussion_r721386337), but broken out to keep things moving.

This merges `ErrorKind::NoAcknowledgeData` and `ErrorKind::NoAcknowledgeAddress` into one variant with a source field to indicate what the NACK was in response to. Some drivers may not be able to differentiate between NACKs on address or data bytes so they should use `NoAcknowledgeSource::Unknown`.

Feel free to bikeshed names and documentation. I used the most obvious names to me, but naming is one of the hardest problems in programming.