### PR TITLE
add default SPI word types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Default SPI word types
 - Added `Can` Controller Area Network traits.
 - `Error` traits for SPI, I2C and Serial traits. The error types used in those must
   implement these `Error` traits, which implies providing a conversion to a common

--- a/src/spi/blocking.rs
+++ b/src/spi/blocking.rs
@@ -4,8 +4,10 @@
 //! traits. To save boilerplate when that's the case a `Default` marker trait may be provided.
 //! Implementing that marker trait will opt in your type into a blanket implementation.
 
+use super::U8;
+
 /// Blocking transfer
-pub trait Transfer<W> {
+pub trait Transfer<W = U8> {
     /// Error type
     type Error: crate::spi::Error;
 
@@ -24,7 +26,7 @@ impl<T: Transfer<W>, W> Transfer<W> for &mut T {
 }
 
 /// Blocking write
-pub trait Write<W> {
+pub trait Write<W = U8> {
     /// Error type
     type Error: crate::spi::Error;
 
@@ -41,7 +43,7 @@ impl<T: Write<W>, W> Write<W> for &mut T {
 }
 
 /// Blocking write (iterator version)
-pub trait WriteIter<W> {
+pub trait WriteIter<W = U8> {
     /// Error type
     type Error: crate::spi::Error;
 
@@ -66,7 +68,7 @@ impl<T: WriteIter<W>, W> WriteIter<W> for &mut T {
 ///
 /// This allows composition of SPI operations into a single bus transaction
 #[derive(Debug, PartialEq)]
-pub enum Operation<'a, W: 'static> {
+pub enum Operation<'a, W: 'static = U8> {
     /// Write data from the provided buffer, discarding read data
     Write(&'a [W]),
     /// Write data out while reading data into the provided buffer
@@ -75,7 +77,7 @@ pub enum Operation<'a, W: 'static> {
 
 /// Transactional trait allows multiple actions to be executed
 /// as part of a single SPI transaction
-pub trait Transactional<W: 'static> {
+pub trait Transactional<W: 'static = U8> {
     /// Associated error type
     type Error: crate::spi::Error;
 

--- a/src/spi/blocking.rs
+++ b/src/spi/blocking.rs
@@ -4,61 +4,70 @@
 //! traits. To save boilerplate when that's the case a `Default` marker trait may be provided.
 //! Implementing that marker trait will opt in your type into a blanket implementation.
 
-use super::U8;
+use super::{SpiWord, U8};
 
 /// Blocking transfer
-pub trait Transfer<W = U8> {
+pub trait Transfer<W: SpiWord = U8> {
     /// Error type
     type Error: crate::spi::Error;
 
     /// Writes and reads simultaneously. The contents of `words` are
     /// written to the slave, and the received words are stored into the same
     /// `words` buffer, overwriting it.
-    fn transfer(&mut self, words: &mut [W]) -> Result<(), Self::Error>;
+    fn transfer(&mut self, words: &mut [W::Data]) -> Result<(), Self::Error>;
 }
 
-impl<T: Transfer<W>, W> Transfer<W> for &mut T {
+impl<T: Transfer<W>, W> Transfer<W> for &mut T
+where
+    W: SpiWord,
+{
     type Error = T::Error;
 
-    fn transfer(&mut self, words: &mut [W]) -> Result<(), Self::Error> {
+    fn transfer(&mut self, words: &mut [W::Data]) -> Result<(), Self::Error> {
         T::transfer(self, words)
     }
 }
 
 /// Blocking write
-pub trait Write<W = U8> {
+pub trait Write<W: SpiWord = U8> {
     /// Error type
     type Error: crate::spi::Error;
 
     /// Writes `words` to the slave, ignoring all the incoming words
-    fn write(&mut self, words: &[W]) -> Result<(), Self::Error>;
+    fn write(&mut self, words: &[W::Data]) -> Result<(), Self::Error>;
 }
 
-impl<T: Write<W>, W> Write<W> for &mut T {
+impl<T: Write<W>, W> Write<W> for &mut T
+where
+    W: SpiWord,
+{
     type Error = T::Error;
 
-    fn write(&mut self, words: &[W]) -> Result<(), Self::Error> {
+    fn write(&mut self, words: &[W::Data]) -> Result<(), Self::Error> {
         T::write(self, words)
     }
 }
 
 /// Blocking write (iterator version)
-pub trait WriteIter<W = U8> {
+pub trait WriteIter<W: SpiWord = U8> {
     /// Error type
     type Error: crate::spi::Error;
 
     /// Writes `words` to the slave, ignoring all the incoming words
     fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
     where
-        WI: IntoIterator<Item = W>;
+        WI: IntoIterator<Item = W::Data>;
 }
 
-impl<T: WriteIter<W>, W> WriteIter<W> for &mut T {
+impl<T: WriteIter<W>, W> WriteIter<W> for &mut T
+where
+    W: SpiWord,
+{
     type Error = T::Error;
 
     fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
     where
-        WI: IntoIterator<Item = W>,
+        WI: IntoIterator<Item = W::Data>,
     {
         T::write_iter(self, words)
     }
@@ -68,16 +77,24 @@ impl<T: WriteIter<W>, W> WriteIter<W> for &mut T {
 ///
 /// This allows composition of SPI operations into a single bus transaction
 #[derive(Debug, PartialEq)]
-pub enum Operation<'a, W: 'static = U8> {
+pub enum Operation<'a, W = U8>
+where
+    W: SpiWord,
+    W::Data: 'static,
+{
     /// Write data from the provided buffer, discarding read data
-    Write(&'a [W]),
+    Write(&'a [W::Data]),
     /// Write data out while reading data into the provided buffer
-    Transfer(&'a mut [W]),
+    Transfer(&'a mut [W::Data]),
 }
 
 /// Transactional trait allows multiple actions to be executed
 /// as part of a single SPI transaction
-pub trait Transactional<W: 'static = U8> {
+pub trait Transactional<W = U8>
+where
+    W: SpiWord,
+    W::Data: 'static,
+{
     /// Associated error type
     type Error: crate::spi::Error;
 
@@ -85,7 +102,11 @@ pub trait Transactional<W: 'static = U8> {
     fn exec<'a>(&mut self, operations: &mut [Operation<'a, W>]) -> Result<(), Self::Error>;
 }
 
-impl<T: Transactional<W>, W: 'static> Transactional<W> for &mut T {
+impl<T: Transactional<W>, W> Transactional<W> for &mut T
+where
+    W: SpiWord,
+    W::Data: 'static,
+{
     type Error = T::Error;
 
     fn exec<'a>(&mut self, operations: &mut [Operation<'a, W>]) -> Result<(), Self::Error> {

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -3,6 +3,15 @@
 pub mod blocking;
 pub mod nb;
 
+/// 8-bit SPI Word (default)
+pub type U8 = u8;
+/// 9-bit SPI Word
+pub struct U9;
+/// 16-bit SPI Word
+pub struct U16;
+/// 18-bit SPI Word
+pub struct U18;
+
 /// Clock polarity
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Polarity {

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -1,7 +1,15 @@
 //! SPI traits
 
+use crate::private::Sealed;
+
 pub mod blocking;
 pub mod nb;
+
+/// Marker trait for SPI Word
+pub trait SpiWord: Sealed {
+    /// Specified data size type
+    type Data: Sized;
+}
 
 /// 8-bit SPI Word (default)
 pub type U8 = u8;
@@ -11,6 +19,23 @@ pub struct U9;
 pub struct U16;
 /// 18-bit SPI Word
 pub struct U18;
+
+impl Sealed for U9 {}
+impl Sealed for U16 {}
+impl Sealed for U18 {}
+
+impl SpiWord for U8 {
+    type Data = u8;
+}
+impl SpiWord for U9 {
+    type Data = u16;
+}
+impl SpiWord for U16 {
+    type Data = u16;
+}
+impl SpiWord for U18 {
+    type Data = u32;
+}
 
 /// Clock polarity
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/spi/nb.rs
+++ b/src/spi/nb.rs
@@ -1,6 +1,6 @@
 //! Serial Peripheral Interface
 
-use super::U8;
+use super::{SpiWord, U8};
 
 /// Full duplex (master mode)
 ///
@@ -17,8 +17,8 @@ use super::U8;
 /// The slave select line shouldn't be released before that.
 ///
 /// - Some SPIs can work with 8-bit *and* 16-bit words. You can overload this trait with different
-/// `Word` types to allow operation in both modes.
-pub trait FullDuplex<Word = U8> {
+/// `W` types to allow operation in both modes.
+pub trait FullDuplex<W: SpiWord = U8> {
     /// An enumeration of SPI errors
     type Error: crate::spi::Error;
 
@@ -26,20 +26,23 @@ pub trait FullDuplex<Word = U8> {
     ///
     /// **NOTE** A word must be sent to the slave before attempting to call this
     /// method.
-    fn read(&mut self) -> nb::Result<Word, Self::Error>;
+    fn read(&mut self) -> nb::Result<W::Data, Self::Error>;
 
     /// Writes a word to the slave
-    fn write(&mut self, word: Word) -> nb::Result<(), Self::Error>;
+    fn write(&mut self, word: W::Data) -> nb::Result<(), Self::Error>;
 }
 
-impl<T: FullDuplex<Word>, Word> FullDuplex<Word> for &mut T {
+impl<T: FullDuplex<W>, W> FullDuplex<W> for &mut T
+where
+    W: SpiWord,
+{
     type Error = T::Error;
 
-    fn read(&mut self) -> nb::Result<Word, Self::Error> {
+    fn read(&mut self) -> nb::Result<W::Data, Self::Error> {
         T::read(self)
     }
 
-    fn write(&mut self, word: Word) -> nb::Result<(), Self::Error> {
+    fn write(&mut self, word: W::Data) -> nb::Result<(), Self::Error> {
         T::write(self, word)
     }
 }

--- a/src/spi/nb.rs
+++ b/src/spi/nb.rs
@@ -1,5 +1,7 @@
 //! Serial Peripheral Interface
 
+use super::U8;
+
 /// Full duplex (master mode)
 ///
 /// # Notes
@@ -16,7 +18,7 @@
 ///
 /// - Some SPIs can work with 8-bit *and* 16-bit words. You can overload this trait with different
 /// `Word` types to allow operation in both modes.
-pub trait FullDuplex<Word> {
+pub trait FullDuplex<Word = U8> {
     /// An enumeration of SPI errors
     type Error: crate::spi::Error;
 


### PR DESCRIPTION
Thought about this reading #295

cc @eldruin  @Sh3Rm4n  @ryankurte 

Should we restrict types be some trait?
Can also split `U16` to `U16LE` and `U16BE`