### PR TITLE
Remove docs mentioning the Default marker traits.

### DIFF
--- a/src/digital.rs
+++ b/src/digital.rs
@@ -1,8 +1,4 @@
 //! Digital I/O
-//!
-//! In some cases it's possible to implement these blocking traits on top of one of the core HAL
-//! traits. To save boilerplate when that's the case a `Default` marker trait may be provided.
-//! Implementing that marker trait will opt in your type into a blanket implementation.
 
 use core::{convert::From, ops::Not};
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -16,10 +16,6 @@
 //! Since 7-bit addressing is the mode of the majority of I2C devices,
 //! `SevenBitAddress` has been set as default mode and thus can be omitted if desired.
 //!
-//! In some cases it's possible to implement these blocking traits on top of one of the core HAL
-//! traits. To save boilerplate when that's the case a `Default` marker trait may be provided.
-//! Implementing that marker trait will opt in your type into a blanket implementation.
-//!
 //! ## Examples
 //!
 //! ### `embedded-hal` implementation for an MCU

--- a/src/serial/blocking.rs
+++ b/src/serial/blocking.rs
@@ -1,8 +1,4 @@
 //! Blocking serial API
-//!
-//! In some cases it's possible to implement these blocking traits on top of one of the core HAL
-//! traits. To save boilerplate when that's the case a `Default` marker trait may be provided.
-//! Implementing that marker trait will opt in your type into a blanket implementation.
 
 /// Write half of a serial interface (blocking variant)
 pub trait Write<Word> {

--- a/src/spi/blocking.rs
+++ b/src/spi/blocking.rs
@@ -1,8 +1,4 @@
 //! Blocking SPI API
-//!
-//! In some cases it's possible to implement these blocking traits on top of one of the core HAL
-//! traits. To save boilerplate when that's the case a `Default` marker trait may be provided.
-//! Implementing that marker trait will opt in your type into a blanket implementation.
 
 /// Blocking transfer
 pub trait Transfer<W> {


### PR DESCRIPTION
These were removed in https://github.com/rust-embedded/embedded-hal/pull/289 but
the doc comments were not updated accordingly.