### PR TITLE
spi: group into read-only, write-only and read-write traits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed blanket impl of `DelayUs` not covering the `delay_ms` method.
 ### Changed
 - `spi`: traits now enforce all impls on the same struct (eg `Transfer` and `Write`) have the same `Error` type. 
+- `spi/blocking`: unified traits into `Read`, `Write`, `ReadWrite`.
+- `spi/blocking`: renamed Transactional `exec` to `batch`.
+- `spi/blocking`: Added `read_batch`, `write_batch` methods.
 
 ### Changed
 - `digital`: traits now enforce all impls on the same struct have the same `Error` type.

--- a/src/spi/blocking.rs
+++ b/src/spi/blocking.rs
@@ -2,75 +2,54 @@
 
 use super::ErrorType;
 
-/// Blocking transfer with separate buffers
-pub trait Transfer<Word = u8>: ErrorType {
-    /// Writes and reads simultaneously. `write` is written to the slave on MOSI and
-    /// words received on MISO are stored in `read`.
-    ///
-    /// It is allowed for `read` and `write` to have different lengths, even zero length.
-    /// The transfer runs for `max(read.len(), write.len())` words. If `read` is shorter,
-    /// incoming words after `read` has been filled will be discarded. If `write` is shorter,
-    /// the value of words sent in MOSI after all `write` has been sent is implementation-defined,
-    /// typically `0x00`, `0xFF`, or configurable.
-    fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error>;
-}
-
-impl<T: Transfer<Word>, Word: Copy> Transfer<Word> for &mut T {
-    fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error> {
-        T::transfer(self, read, write)
-    }
-}
-
-/// Blocking transfer with single buffer (in-place)
-pub trait TransferInplace<Word: Copy = u8>: ErrorType {
-    /// Writes and reads simultaneously. The contents of `words` are
-    /// written to the slave, and the received words are stored into the same
-    /// `words` buffer, overwriting it.
-    fn transfer_inplace(&mut self, words: &mut [Word]) -> Result<(), Self::Error>;
-}
-
-impl<T: TransferInplace<Word>, Word: Copy> TransferInplace<Word> for &mut T {
-    fn transfer_inplace(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
-        T::transfer_inplace(self, words)
-    }
-}
-
-/// Blocking read
+/// Blocking read-only SPI
 pub trait Read<Word: Copy = u8>: ErrorType {
     /// Reads `words` from the slave.
     ///
     /// The word value sent on MOSI during reading is implementation-defined,
     /// typically `0x00`, `0xFF`, or configurable.
     fn read(&mut self, words: &mut [Word]) -> Result<(), Self::Error>;
+
+    /// Reads all slices in `words` from the slave as part of a single SPI transaction.
+    ///
+    /// The word value sent on MOSI during reading is implementation-defined,
+    /// typically `0x00`, `0xFF`, or configurable.
+    fn read_transaction(&mut self, words: &mut [&mut [Word]]) -> Result<(), Self::Error>;
 }
 
 impl<T: Read<Word>, Word: Copy> Read<Word> for &mut T {
     fn read(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
         T::read(self, words)
     }
-}
 
-/// Blocking write
-pub trait Write<Word: Copy = u8>: ErrorType {
-    /// Writes `words` to the slave, ignoring all the incoming words
-    fn write(&mut self, words: &[Word]) -> Result<(), Self::Error>;
-}
-
-impl<T: Write<Word>, Word: Copy> Write<Word> for &mut T {
-    fn write(&mut self, words: &[Word]) -> Result<(), Self::Error> {
-        T::write(self, words)
+    fn read_transaction(&mut self, words: &mut [&mut [Word]]) -> Result<(), Self::Error> {
+        T::read_transaction(self, words)
     }
 }
 
-/// Blocking write (iterator version)
-pub trait WriteIter<Word: Copy = u8>: ErrorType {
+/// Blocking write-only SPI
+pub trait Write<Word: Copy = u8>: ErrorType {
+    /// Writes `words` to the slave, ignoring all the incoming words
+    fn write(&mut self, words: &[Word]) -> Result<(), Self::Error>;
+
+    /// Writes all slices in `words` to the slave as part of a single SPI transaction, ignoring all the incoming words
+    fn write_transaction(&mut self, words: &[&[Word]]) -> Result<(), Self::Error>;
+
     /// Writes `words` to the slave, ignoring all the incoming words
     fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
     where
         WI: IntoIterator<Item = Word>;
 }
 
-impl<T: WriteIter<Word>, Word: Copy> WriteIter<Word> for &mut T {
+impl<T: Write<Word>, Word: Copy> Write<Word> for &mut T {
+    fn write(&mut self, words: &[Word]) -> Result<(), Self::Error> {
+        T::write(self, words)
+    }
+
+    fn write_transaction(&mut self, words: &[&[Word]]) -> Result<(), Self::Error> {
+        T::write_transaction(self, words)
+    }
+
     fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
     where
         WI: IntoIterator<Item = Word>,
@@ -79,7 +58,7 @@ impl<T: WriteIter<Word>, Word: Copy> WriteIter<Word> for &mut T {
     }
 }
 
-/// Operation for transactional SPI trait
+/// Operation for ReadWrite::transaction
 ///
 /// This allows composition of SPI operations into a single bus transaction
 #[derive(Debug, PartialEq)]
@@ -91,18 +70,46 @@ pub enum Operation<'a, Word: 'static + Copy = u8> {
     /// Write data out while reading data into the provided buffer
     Transfer(&'a mut [Word], &'a [Word]),
     /// Write data out while reading data into the provided buffer
-    TransferInplace(&'a mut [Word]),
+    TransferInPlace(&'a mut [Word]),
 }
 
-/// Transactional trait allows multiple actions to be executed
-/// as part of a single SPI transaction
-pub trait Transactional<Word: 'static + Copy = u8>: ErrorType {
-    /// Execute the provided transactions
-    fn exec<'a>(&mut self, operations: &mut [Operation<'a, Word>]) -> Result<(), Self::Error>;
+/// Blocking read-write SPI
+pub trait ReadWrite<Word: Copy = u8>: Read<Word> + Write<Word> {
+    /// Writes and reads simultaneously. `write` is written to the slave on MOSI and
+    /// words received on MISO are stored in `read`.
+    ///
+    /// It is allowed for `read` and `write` to have different lengths, even zero length.
+    /// The transfer runs for `max(read.len(), write.len())` words. If `read` is shorter,
+    /// incoming words after `read` has been filled will be discarded. If `write` is shorter,
+    /// the value of words sent in MOSI after all `write` has been sent is implementation-defined,
+    /// typically `0x00`, `0xFF`, or configurable.
+    fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error>;
+
+    /// Writes and reads simultaneously. The contents of `words` are
+    /// written to the slave, and the received words are stored into the same
+    /// `words` buffer, overwriting it.
+    fn transfer_in_place(&mut self, words: &mut [Word]) -> Result<(), Self::Error>;
+
+    /// Execute multiple actions as part of a single SPI transaction
+    fn transaction<'a>(
+        &mut self,
+        operations: &mut [Operation<'a, Word>],
+    ) -> Result<(), Self::Error>;
 }
 
-impl<T: Transactional<Word>, Word: 'static + Copy> Transactional<Word> for &mut T {
-    fn exec<'a>(&mut self, operations: &mut [Operation<'a, Word>]) -> Result<(), Self::Error> {
-        T::exec(self, operations)
+impl<T: ReadWrite<Word>, Word: Copy> ReadWrite<Word> for &mut T {
+    fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error> {
+        T::transfer(self, read, write)
+    }
+
+    fn transfer_in_place(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
+        T::transfer_in_place(self, words)
+    }
+
+    fn transaction<'a>(
+        &mut self,
+        operations: &mut [Operation<'a, Word>],
+    ) -> Result<(), Self::Error> {
+        T::transaction(self, operations)
     }
 }


### PR DESCRIPTION
This PR depends on #331

## The problem

Currently, embedded-hal has independent traits for every single method. The rationale is to allow HALs to only implement what they support. For example, a HAL could allow setting up an SPI with a MOSI pin but no MISO pin. This would be a "write-only" SPI, so the resulting struct would implement `write` and `write_iter`, but not other methods like `read` or `transfer`. This is awesome, because it enforces *at compile time* that you can't pass a write-only SPI to a driver that needs a read-write SPI.

However, splitting *one trait per method* is way too granular. It leaves too much room for variability in HAL implementations. I've done a quick survey of which HAL implements which traits, here's the result:

|                         | Transfer | Write | WriteIter | Transactional |
|-------------------------|----------|-------|-----------|---------------|
| stm32f1xx-hal           | x        | x     |           |               |
| stm32f3xx-hal           | x        | x     |           |               |
| stm32f4xx-hal           | x        | x     | x         | x             |
| stm32f7xx-hal           | x        | x     | x         |               |
| stm32h7xx-hal           | x        | x     |           |               |
| stm32l0xx-hal           | x        | x     |           |               |
| stm32l4xx-hal           | x        | x     |           |               |
| stm32g4xx-hal           | x        | x     |           |               |
| David-OConnor/stm32-hal | x        | x     |           |               |
| nrf-hal SPI             | x        | x     | x         |               |
| nrf-hal SPIM            | x        | x     |           |               |
| esp32-hal               | x        | x     | x         |               |
| esp-idf-hal             | x        | x     | x         |               |
| linux-embedded-hal      | x        | x     |           | x             |
| atsamd-hal              | x        | x     | x         |               |
| lpc55s6x-hal            | x        | x     | x         |               |
| imxrt-hal               | x        | x     | x         |               |
| e310x-hal               | x        | x     | x         |               |

As you can see, all HALs implement `write` and `transfer`, but only about half implement `write_iter` and almost none implements `transactional`. 

The result is drivers can't reliably rely on `Transactional` or `WriteIter` being present, so they stick to `Transfer` and `Write` to ensure maximum HAL compatibility. This in turn means HALs have little incentive to implement `Transactional` and `WriteIter` since no drivers use them. This causes a chicken-and-egg situation, which in the end makes `Transactional` and `WriteIter` useless for drivers in practice.

(Too much freedom for HALs causing traits to not be useful for drivers is a common theme in e-h. For example #312 and #201 are the same. IMO e-h should be slightly more opinionated in general. Just enough opinionatedness to force HAL impls to be consistent to be useful for drivers.)

## The solution

The solution is to split the traits *by hardware capability*, not by method.

- If an SPI is capable of `write`, it's capable of `write_iter`. It can write bytes, after all. There's no reason to allow a HAL to implement `write` but not `write_iter`.
- If an SPI is capable of `transfer`, there's no reason it can't  `transfer_inplace`, `transactional`, `read`, `write`, etc. If it can read *and* write, it should be able to do all the kinds of reads/writes we have.

So, I propose we split the traits like this:
- `Read`: read-only SPI.
- `Write`: write-only SPI. It supports all the forms of writing: `write` and `write_iter`.
- `ReadWrite`: read-write SPI. It requires `Read` and `Write`, and supports all the forms of bidirectional transfers: `transfer`, `transfer_inplace`, `transactional`.

This way HALs keep the "good" freedom to declare their SPI is readonly/writeonly, but they no longer have the "bad" freedom of only implementing the basic traits making the advanced traits useless.

## Other traits

I believe this should be also applied to the other traits. I propose discussing this in the context of SPI here, and if the consensus is it's good I'll send PRs doing the same for the other traits.