### PR TITLE
Require all SPI and Serial word types to be `Copy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Use `u8` as default SPI as Serial Word type
 - The Minimum Supported Rust Version (MSRV) is now 1.46.0
+- Require all SPI and Serial word types to be `Copy`.
 
 ### Added
 - Added `Can` Controller Area Network traits.

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -6,7 +6,7 @@ use core::fmt::{Result, Write};
 impl<Word, Error: crate::serial::Error> Write
     for dyn crate::serial::nb::Write<Word, Error = Error> + '_
 where
-    Word: From<u8>,
+    Word: Copy + From<u8>,
 {
     fn write_str(&mut self, s: &str) -> Result {
         let _ = s

--- a/src/serial/blocking.rs
+++ b/src/serial/blocking.rs
@@ -1,7 +1,7 @@
 //! Blocking serial API
 
 /// Write half of a serial interface (blocking variant)
-pub trait Write<Word = u8> {
+pub trait Write<Word: Copy = u8> {
     /// The type of error that can occur when writing
     type Error: crate::serial::Error;
 
@@ -19,7 +19,7 @@ pub trait Write<Word = u8> {
     fn flush(&mut self) -> Result<(), Self::Error>;
 }
 
-impl<T: Write<Word>, Word> Write<Word> for &mut T {
+impl<T: Write<Word>, Word: Copy> Write<Word> for &mut T {
     type Error = T::Error;
 
     fn write(&mut self, buffer: &[Word]) -> Result<(), Self::Error> {

--- a/src/serial/nb.rs
+++ b/src/serial/nb.rs
@@ -4,7 +4,7 @@
 ///
 /// Some serial interfaces support different data sizes (8 bits, 9 bits, etc.);
 /// This can be encoded in this trait via the `Word` type parameter.
-pub trait Read<Word = u8> {
+pub trait Read<Word: Copy = u8> {
     /// Read error
     type Error: crate::serial::Error;
 
@@ -12,7 +12,7 @@ pub trait Read<Word = u8> {
     fn read(&mut self) -> nb::Result<Word, Self::Error>;
 }
 
-impl<T: Read<Word>, Word> Read<Word> for &mut T {
+impl<T: Read<Word>, Word: Copy> Read<Word> for &mut T {
     type Error = T::Error;
 
     fn read(&mut self) -> nb::Result<Word, Self::Error> {
@@ -21,7 +21,7 @@ impl<T: Read<Word>, Word> Read<Word> for &mut T {
 }
 
 /// Write half of a serial interface
-pub trait Write<Word = u8> {
+pub trait Write<Word: Copy = u8> {
     /// Write error
     type Error: crate::serial::Error;
 
@@ -32,7 +32,7 @@ pub trait Write<Word = u8> {
     fn flush(&mut self) -> nb::Result<(), Self::Error>;
 }
 
-impl<T: Write<Word>, Word> Write<Word> for &mut T {
+impl<T: Write<Word>, Word: Copy> Write<Word> for &mut T {
     type Error = T::Error;
 
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error> {

--- a/src/spi/blocking.rs
+++ b/src/spi/blocking.rs
@@ -1,7 +1,7 @@
 //! Blocking SPI API
 
 /// Blocking transfer with separate buffers
-pub trait Transfer<W = u8> {
+pub trait Transfer<W: Copy = u8> {
     /// Error type
     type Error: crate::spi::Error;
 
@@ -16,7 +16,7 @@ pub trait Transfer<W = u8> {
     fn transfer(&mut self, read: &mut [W], write: &[W]) -> Result<(), Self::Error>;
 }
 
-impl<T: Transfer<W>, W> Transfer<W> for &mut T {
+impl<T: Transfer<W>, W: Copy> Transfer<W> for &mut T {
     type Error = T::Error;
 
     fn transfer(&mut self, read: &mut [W], write: &[W]) -> Result<(), Self::Error> {
@@ -25,7 +25,7 @@ impl<T: Transfer<W>, W> Transfer<W> for &mut T {
 }
 
 /// Blocking transfer with single buffer (in-place)
-pub trait TransferInplace<W = u8> {
+pub trait TransferInplace<W: Copy = u8> {
     /// Error type
     type Error: crate::spi::Error;
 
@@ -35,7 +35,7 @@ pub trait TransferInplace<W = u8> {
     fn transfer_inplace(&mut self, words: &mut [W]) -> Result<(), Self::Error>;
 }
 
-impl<T: TransferInplace<W>, W> TransferInplace<W> for &mut T {
+impl<T: TransferInplace<W>, W: Copy> TransferInplace<W> for &mut T {
     type Error = T::Error;
 
     fn transfer_inplace(&mut self, words: &mut [W]) -> Result<(), Self::Error> {
@@ -44,7 +44,7 @@ impl<T: TransferInplace<W>, W> TransferInplace<W> for &mut T {
 }
 
 /// Blocking read
-pub trait Read<W = u8> {
+pub trait Read<W: Copy = u8> {
     /// Error type
     type Error: crate::spi::Error;
 
@@ -55,7 +55,7 @@ pub trait Read<W = u8> {
     fn read(&mut self, words: &mut [W]) -> Result<(), Self::Error>;
 }
 
-impl<T: Read<W>, W> Read<W> for &mut T {
+impl<T: Read<W>, W: Copy> Read<W> for &mut T {
     type Error = T::Error;
 
     fn read(&mut self, words: &mut [W]) -> Result<(), Self::Error> {
@@ -64,7 +64,7 @@ impl<T: Read<W>, W> Read<W> for &mut T {
 }
 
 /// Blocking write
-pub trait Write<W = u8> {
+pub trait Write<W: Copy = u8> {
     /// Error type
     type Error: crate::spi::Error;
 
@@ -72,7 +72,7 @@ pub trait Write<W = u8> {
     fn write(&mut self, words: &[W]) -> Result<(), Self::Error>;
 }
 
-impl<T: Write<W>, W> Write<W> for &mut T {
+impl<T: Write<W>, W: Copy> Write<W> for &mut T {
     type Error = T::Error;
 
     fn write(&mut self, words: &[W]) -> Result<(), Self::Error> {
@@ -81,7 +81,7 @@ impl<T: Write<W>, W> Write<W> for &mut T {
 }
 
 /// Blocking write (iterator version)
-pub trait WriteIter<W = u8> {
+pub trait WriteIter<W: Copy = u8> {
     /// Error type
     type Error: crate::spi::Error;
 
@@ -91,7 +91,7 @@ pub trait WriteIter<W = u8> {
         WI: IntoIterator<Item = W>;
 }
 
-impl<T: WriteIter<W>, W> WriteIter<W> for &mut T {
+impl<T: WriteIter<W>, W: Copy> WriteIter<W> for &mut T {
     type Error = T::Error;
 
     fn write_iter<WI>(&mut self, words: WI) -> Result<(), Self::Error>
@@ -106,7 +106,7 @@ impl<T: WriteIter<W>, W> WriteIter<W> for &mut T {
 ///
 /// This allows composition of SPI operations into a single bus transaction
 #[derive(Debug, PartialEq)]
-pub enum Operation<'a, W: 'static = u8> {
+pub enum Operation<'a, W: 'static + Copy = u8> {
     /// Read data into the provided buffer.
     Read(&'a mut [W]),
     /// Write data from the provided buffer, discarding read data
@@ -119,7 +119,7 @@ pub enum Operation<'a, W: 'static = u8> {
 
 /// Transactional trait allows multiple actions to be executed
 /// as part of a single SPI transaction
-pub trait Transactional<W: 'static = u8> {
+pub trait Transactional<W: 'static + Copy = u8> {
     /// Associated error type
     type Error: crate::spi::Error;
 
@@ -127,7 +127,7 @@ pub trait Transactional<W: 'static = u8> {
     fn exec<'a>(&mut self, operations: &mut [Operation<'a, W>]) -> Result<(), Self::Error>;
 }
 
-impl<T: Transactional<W>, W: 'static> Transactional<W> for &mut T {
+impl<T: Transactional<W>, W: 'static + Copy> Transactional<W> for &mut T {
     type Error = T::Error;
 
     fn exec<'a>(&mut self, operations: &mut [Operation<'a, W>]) -> Result<(), Self::Error> {

--- a/src/spi/nb.rs
+++ b/src/spi/nb.rs
@@ -16,7 +16,7 @@
 ///
 /// - Some SPIs can work with 8-bit *and* 16-bit words. You can overload this trait with different
 /// `Word` types to allow operation in both modes.
-pub trait FullDuplex<Word = u8> {
+pub trait FullDuplex<Word: Copy = u8> {
     /// An enumeration of SPI errors
     type Error: crate::spi::Error;
 
@@ -30,7 +30,7 @@ pub trait FullDuplex<Word = u8> {
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error>;
 }
 
-impl<T: FullDuplex<Word>, Word> FullDuplex<Word> for &mut T {
+impl<T: FullDuplex<Word>, Word: Copy> FullDuplex<Word> for &mut T {
     type Error = T::Error;
 
     fn read(&mut self) -> nb::Result<Word, Self::Error> {


### PR DESCRIPTION
The word type should always be a builtin integer (`u8`, `u16`, etc) or a newtype to represent an integer with an unusual size, which will almost certainly be `Copy`.

I also removed the `'static` bound from the spi transactional stuff because it appears to be unnecessarily now.