### PR TITLE
Implement all I2C traits for `&RefCell`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - `Error` traits for Can, SPI, I2C and Serial are implemented for Infallible
+- Implement all I2C traits for `&RefCell`
 
 ## [v1.0.0-alpha.6] - 2021-11-19
 


### PR DESCRIPTION
This allows an I2C bus to safely be shared between device drivers. Note that it does *not* allow the bus to be shared between threads/interrupts because `RefCell` is not `Sync` and therefore `&RefCell` is not `Send`.

## Alternatives

### Third party crate

This could be implemented in a third party crate via a wrapper type, but I don't want to maintain an entire crate that is almost entirely boilerplate.

### Use `RefCell::try_borrow_mut`

This could also be implemented using `RefCell::try_borrow_mut`, but that would require a new error enum:
```rust
pub enum I2cRefCellError<E> {
	I2c(E),
	RefCell(core::cell::BorrowMutError)
}
```

The RefCell borrow will only fail if the user has manually borrowed from it (an obvious bug that should be caught immediately during development), so I don't think that it is worth the extra complexity to avoid a panic in that case.

