### PR TITLE
Remove unresolved link to `toggleable`

### DIFF
--- a/src/digital.rs
+++ b/src/digital.rs
@@ -113,11 +113,6 @@ pub mod blocking {
     }
 
     /// Output pin that can be toggled
-    ///
-    /// See [toggleable](toggleable) to use a software implementation if
-    /// both [OutputPin](trait.OutputPin.html) and
-    /// [StatefulOutputPin](trait.StatefulOutputPin.html) are
-    /// implemented. Otherwise, implement this using hardware mechanisms.
     pub trait ToggleableOutputPin {
         /// Error type
         type Error: core::fmt::Debug;


### PR DESCRIPTION
In 282320b `mod toggleable` as the default implementation was removed,
which invalidated the link in the doc comment to it.

This just removes the reference to this non-existing mod, to fix the
issue.