### PR TITLE
delay: fix blanket impl not covering delay_ms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `Error` traits for Can, SPI, I2C and Serial are implemented for Infallible
 
+### Fixed
+- Fixed blanket impl of `DelayUs` not covering the `delay_ms` method.
+
 ## [v1.0.0-alpha.6] - 2021-11-19
 
 *** This is (also) an alpha release with breaking changes (sorry) ***

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -39,5 +39,9 @@ pub mod blocking {
         fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
             T::delay_us(self, us)
         }
+
+        fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+            T::delay_ms(self, ms)
+        }
     }
 }


### PR DESCRIPTION
If an impl overrides the default impl for delay_ms, it was ignored when used through the blanket impl.