### PR TITLE
Set merge=union Git attribute for CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
Currently all PRs add a line to CHANGELOG.md, usually at the end. This means
they almost always run into merge conflicts since they are adding different lines at the exact same
place in the file.

With merge=union Git will automatically resolve these merge conflicts by keeping all lines from both sides.