### PR TITLE
i2c: enforce all traits have the same Error type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed blanket impl of `DelayUs` not covering the `delay_ms` method.
 
+### Changed
+- `i2c`: traits now enforce all impls on the same struct have the same `Error` type.
+
 ## [v1.0.0-alpha.6] - 2021-11-19
 
 *** This is (also) an alpha release with breaking changes (sorry) ***


### PR DESCRIPTION
Equivalent of #331 for i2c.