### PR TITLE
I2c unify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - `i2c`: traits now enforce all impls on the same struct have the same `Error` type.
+- `i2c`: unify all traits into a single `I2c` trait.
 
 ## [v1.0.0-alpha.6] - 2021-11-19
 


### PR DESCRIPTION
Depends on #336 

Equivalent of #323 but for I2c.

I think for i2c unifying everything in a single trait makes the most sense. The i2c bus is specified to be bidirectional, I believe no hardware out there can "only write" or "only read" (and writing requires *reading* ACK bits anyway!).

