### PR TITLE
async: add DelayUs

### DIFF
--- a/.github/workflows/clippy-async.yml
+++ b/.github/workflows/clippy-async.yml
@@ -5,16 +5,15 @@ on:
 
 name: Clippy check
 jobs:
-  clippy_check:
+  clippy_check-async:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
           components: clippy
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo clippy
+        working-directory: embedded-hal-async

--- a/embedded-hal-async/src/delay.rs
+++ b/embedded-hal-async/src/delay.rs
@@ -1,0 +1,52 @@
+//! Delays
+
+use core::future::Future;
+
+/// Microsecond delay
+pub trait DelayUs {
+    /// Enumeration of errors
+    type Error: core::fmt::Debug;
+
+    /// The future returned by the `delay_us` function.
+    type DelayUsFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    where
+        Self: 'a;
+
+    /// Pauses execution for at minimum `us` microseconds. Pause can be longer
+    /// if the implementation requires it due to precision/timing issues.
+    fn delay_us(&mut self, us: u32) -> Self::DelayUsFuture<'_>;
+
+    /// The future returned by the `delay_ms` function.
+    type DelayMsFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    where
+        Self: 'a;
+
+    /// Pauses execution for at minimum `ms` milliseconds. Pause can be longer
+    /// if the implementation requires it due to precision/timing issues.
+    fn delay_ms(&mut self, ms: u32) -> Self::DelayMsFuture<'_>;
+}
+
+impl<T> DelayUs for &mut T
+where
+    T: DelayUs,
+{
+    type Error = T::Error;
+
+    type DelayUsFuture<'a>
+    where
+        Self: 'a,
+    = T::DelayUsFuture<'a>;
+
+    fn delay_us(&mut self, us: u32) -> Self::DelayUsFuture<'_> {
+        T::delay_us(self, us)
+    }
+
+    type DelayMsFuture<'a>
+    where
+        Self: 'a,
+    = T::DelayMsFuture<'a>;
+
+    fn delay_ms(&mut self, ms: u32) -> Self::DelayMsFuture<'_> {
+        T::delay_ms(self, ms)
+    }
+}

--- a/embedded-hal-async/src/lib.rs
+++ b/embedded-hal-async/src/lib.rs
@@ -9,3 +9,4 @@
 
 #![deny(missing_docs)]
 #![no_std]
+#![feature(generic_associated_types)]

--- a/embedded-hal-async/src/lib.rs
+++ b/embedded-hal-async/src/lib.rs
@@ -10,3 +10,5 @@
 #![deny(missing_docs)]
 #![no_std]
 #![feature(generic_associated_types)]
+
+pub mod delay;


### PR DESCRIPTION
Add async DelayUs, mirroring the blocking one.

Unlike blocking, `delay_ms` has no default impl because it's not possible to have default impls in GAT-based async traits.