### PR TITLE
Remove Into<Time> generics

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -47,7 +47,7 @@ pub mod nb {
     /// #     fn disable(&mut self, _: Channel) -> Result<(), Self::Error> { unimplemented!() }
     /// #     fn enable(&mut self, _: Channel) -> Result<(), Self::Error> { unimplemented!() }
     /// #     fn get_resolution(&self) -> Result<MilliSeconds, Self::Error> { unimplemented!() }
-    /// #     fn set_resolution<T>(&mut self, _: T) -> Result<(), Self::Error> where T: Into<MilliSeconds> { Ok(()) }
+    /// #     fn set_resolution(&mut self, _: MilliSeconds) -> Result<(), Self::Error> { Ok(()) }
     /// # }
     /// ```
     // unproven reason: pre-singletons API. With singletons a `CapturePin` (cf. `PwmPin`) trait seems more
@@ -90,9 +90,7 @@ pub mod nb {
         fn get_resolution(&self) -> Result<Self::Time, Self::Error>;
 
         /// Sets the resolution of the capture timer
-        fn set_resolution<R>(&mut self, resolution: R) -> Result<(), Self::Error>
-        where
-            R: Into<Self::Time>;
+        fn set_resolution(&mut self, resolution: Self::Time) -> Result<(), Self::Error>;
     }
 
     impl<T: Capture> Capture for &mut T {
@@ -120,10 +118,7 @@ pub mod nb {
             T::get_resolution(self)
         }
 
-        fn set_resolution<R>(&mut self, resolution: R) -> Result<(), Self::Error>
-        where
-            R: Into<Self::Time>,
-        {
+        fn set_resolution(&mut self, resolution: Self::Time) -> Result<(), Self::Error> {
             T::set_resolution(self, resolution)
         }
     }

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -47,7 +47,7 @@ pub mod blocking {
     /// #     fn get_max_duty(&self) -> Result<u16, Self::Error> { Ok(0) }
     /// #     fn set_duty(&mut self, _: &Channel, _: u16) -> Result<(), Self::Error> { Ok(()) }
     /// #     fn get_period(&self) -> Result<KiloHertz, Self::Error> { unimplemented!() }
-    /// #     fn set_period<T>(&mut self, _: T) -> Result<(), Self::Error> where T: Into<KiloHertz> { Ok(()) }
+    /// #     fn set_period(&mut self, _: KiloHertz) -> Result<(), Self::Error> { Ok(()) }
     /// # }
     /// ```
     // unproven reason: pre-singletons API. The `PwmPin` trait seems more useful because it models independent
@@ -97,9 +97,7 @@ pub mod blocking {
         ) -> Result<(), Self::Error>;
 
         /// Sets a new PWM period
-        fn set_period<P>(&mut self, period: P) -> Result<(), Self::Error>
-        where
-            P: Into<Self::Time>;
+        fn set_period(&mut self, period: Self::Time) -> Result<(), Self::Error>;
     }
 
     impl<T: Pwm> Pwm for &mut T {
@@ -139,10 +137,7 @@ pub mod blocking {
             T::set_duty(self, channel, duty)
         }
 
-        fn set_period<P>(&mut self, period: P) -> Result<(), Self::Error>
-        where
-            P: Into<Self::Time>,
-        {
+        fn set_period(&mut self, period: Self::Time) -> Result<(), Self::Error> {
             T::set_period(self, period)
         }
     }

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -62,7 +62,7 @@ pub mod blocking {
     /// # impl hal::timer::nb::CountDown for Timer6 {
     /// #     type Error = Infallible;
     /// #     type Time = Seconds;
-    /// #     fn start<T>(&mut self, _: T) -> Result<(), Infallible> where T: Into<Seconds> { Ok(()) }
+    /// #     fn start(&mut self, _: Seconds) -> Result<(), Infallible> { Ok(()) }
     /// #     fn wait(&mut self) -> ::nb::Result<(), Infallible> { Ok(()) }
     /// # }
     /// ```

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -56,7 +56,7 @@ pub mod nb {
     /// # impl hal::timer::nb::CountDown for Timer6 {
     /// #     type Error = Infallible;
     /// #     type Time = Seconds;
-    /// #     fn start<T>(&mut self, _: T) -> Result<(), Self::Error> where T: Into<Seconds> { Ok(()) }
+    /// #     fn start(&mut self, _: Seconds) -> Result<(), Self::Error> { Ok(()) }
     /// #     fn wait(&mut self) -> ::nb::Result<(), Infallible> { Ok(()) }
     /// # }
     /// ```
@@ -70,9 +70,7 @@ pub mod nb {
         type Time;
 
         /// Starts a new count down
-        fn start<T>(&mut self, count: T) -> Result<(), Self::Error>
-        where
-            T: Into<Self::Time>;
+        fn start(&mut self, count: Self::Time) -> Result<(), Self::Error>;
 
         /// Non-blockingly "waits" until the count down finishes
         ///
@@ -90,10 +88,7 @@ pub mod nb {
 
         type Time = T::Time;
 
-        fn start<TIME>(&mut self, count: TIME) -> Result<(), Self::Error>
-        where
-            TIME: Into<Self::Time>,
-        {
+        fn start(&mut self, count: Self::Time) -> Result<(), Self::Error> {
             T::start(self, count)
         }
 

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -44,9 +44,7 @@ pub mod blocking {
         ///
         /// This consumes the value and returns the `Watchdog` trait that you must
         /// `feed()`.
-        fn start<T>(self, period: T) -> Result<Self::Target, Self::Error>
-        where
-            T: Into<Self::Time>;
+        fn start(self, period: Self::Time) -> Result<Self::Target, Self::Error>;
     }
 
     /// Disables a running watchdog timer so the processor won't be reset.


### PR DESCRIPTION
Reason:
`fugit` uses it's own convertion technic and works bad with `Into`. Same as `embedded-time` don't use `Into` for potentially fallible convertions