### PR TITLE
Document MSRV upgrade and improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ version and an `-alpha` version side by side in a HAL.
 
 - [How-to: add a new trait](docs/how-to-add-a-new-trait.md)
 - [Version policy](docs/version-policy.md)
+- [MSRV](docs/msrv.md)
 
 ## Implementations and drivers
 
@@ -72,6 +73,8 @@ on crates.io.
 
 This crate is guaranteed to compile on stable Rust 1.46 and up. It *might*
 compile with older versions but that may change in any new patch release.
+
+See [here](docs/msrv.md) for details on how the MSRV may be upgraded.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ these drivers for their platform.
 
 For functionality that goes beyond what is provided by `embedded-hal`, users are encouraged
 to use the target platform directly. Abstractions of common functionality can be proposed to be
-included into `embedded-hal` as described [below](#how-to-add-a-new-trait), though.
+included into `embedded-hal` as described [in this guide](docs/how-to-add-a-new-trait.md), though.
 
 See more about the design goals in [this documentation section](https://docs.rs/embedded-hal/latest/embedded_hal/#design-goals).
 
@@ -48,36 +48,11 @@ side by side in a HAL.
 
 [#177]: https://github.com/rust-embedded/embedded-hal/issues/177
 
-## How-to: add a new trait
+## Documents
 
-This is the suggested approach to adding a new trait to `embedded-hal`
-
-### Research / Discussion
-
-Ideally, before proposing a new trait, or set of traits, you should check for an existing issue
-suggesting the need for the trait, as well as any related works / use cases / requirements that
-are useful to consider in the design of the trait.
-
-These issues will be labeled as `discussion` in the issue tracker.
-
-### Implementation / Demonstration
-
-Proposed traits should then be implemented and demonstrated, either by forking `embedded-hal` or by creating a new crate with the intent of integrating this into `embedded-hal` once the traits have stabilized. You may find [cargo workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) and [patch](https://doc.rust-lang.org/edition-guide/rust-2018/cargo-and-crates-io/replacing-dependencies-with-patch.html) useful for the forking approach.
-
-Traits should be demonstrated with at least *two* implementations on different platforms and *one* generic driver built on the trait. Where it is possible we suggest an implementation on a microcontroller, and implementation for [linux](https://github.com/rust-embedded/linux-embedded-hal), and a driver (or drivers where requirements are more complex) with bounds using the trait.
-
-### Proposing a trait
-
-Once the trait has been demonstrated a PR should be opened to merge the new trait(s) into `embedded-hal`. This should include a link to the previous discussion issue.
-
-If there is determined to be more than one alternative then there should be further discussion to
-try to single out the best option. Once there is consensus this will be merged into the `embedded-hal` repository.
-
-These issues / PRs will be labeled as `proposal`s in the issue tracker.
-
+- [How-to: add a new trait](docs/how-to-add-a-new-trait.md)
 
 ## Implementations and drivers
-
 For a list of `embedded-hal` implementations and driver crates check the [awesome-embedded-rust]
 list.
 

--- a/README.md
+++ b/README.md
@@ -43,33 +43,21 @@ They are provided as early previews for community testing and preparation for th
 If you use an alpha release, we recommend you choose an exact version specification in your
 `Cargo.toml` like: `embedded-hal = "=1.0.0-alpha.2"`
 
-See below for a way to implement both an `embedded-hal` `0.2.x` version and an `-alpha` version
-side by side in a HAL.
+See [this guide](docs/version-policy.md) for a way to implement both an `embedded-hal` `0.2.x`
+version and an `-alpha` version side by side in a HAL.
 
 [#177]: https://github.com/rust-embedded/embedded-hal/issues/177
 
 ## Documents
 
 - [How-to: add a new trait](docs/how-to-add-a-new-trait.md)
+- [Version policy](docs/version-policy.md)
 
 ## Implementations and drivers
 For a list of `embedded-hal` implementations and driver crates check the [awesome-embedded-rust]
 list.
 
 [awesome-embedded-rust]: https://github.com/rust-embedded/awesome-embedded-rust#driver-crates
-
-### Supporting different (alpha and non-alpha) HALs
-
-[embedded-hal-compat](https://github.com/ryankurte/embedded-hal-compat) provides shims
-to support interoperability between the latest `0.2.x` and `1.0.0-alpha.N` HALs, allowing one to use
-incompatible HAL components (generally) without alteration.
-See the [docs](https://docs.rs/embedded-hal-compat/) for examples.
-
-It is also possible for HAL implementations to support both the latest `0.2.x` and `1.0.0-alpha.N` versions
-side by side, for an example see [LPC8xx HAL](https://github.com/lpc-rs/lpc8xx-hal).
-
-Note that `embedded-hal` `-alpha` versions are a moving target and _not guaranteed_ to be compatible.
-Because of this we only aim to support the latest `-alpha`.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,17 @@ version and an `-alpha` version side by side in a HAL.
 - [Version policy](docs/version-policy.md)
 
 ## Implementations and drivers
-For a list of `embedded-hal` implementations and driver crates check the [awesome-embedded-rust]
-list.
+
+For a non-exhaustive list of `embedded-hal` implementations and driver crates check the
+[awesome-embedded-rust] list.
+
+You may be able to find even more HAL implementation crates and driver crates by searching for the
+[`embedded-hal-impl`], [`embedded-hal-driver`] and [`embedded-hal`][embedded-hal-kw] keywords
+on crates.io.
+
+[`embedded-hal-impl`]: https://crates.io/keywords/embedded-hal-impl
+[`embedded-hal-driver`]: https://crates.io/keywords/embedded-hal-driver
+[embedded-hal-kw]: https://crates.io/keywords/embedded-hal
 
 [awesome-embedded-rust]: https://github.com/rust-embedded/awesome-embedded-rust#driver-crates
 

--- a/docs/how-to-add-a-new-trait.md
+++ b/docs/how-to-add-a-new-trait.md
@@ -1,0 +1,26 @@
+# How-to: add a new trait
+
+This is the suggested approach to adding a new trait to `embedded-hal`
+
+## Research / Discussion
+
+Ideally, before proposing a new trait, or set of traits, you should check for an existing issue
+suggesting the need for the trait, as well as any related works / use cases / requirements that
+are useful to consider in the design of the trait.
+
+These issues will be labeled as `discussion` in the issue tracker.
+
+## Implementation / Demonstration
+
+Proposed traits should then be implemented and demonstrated, either by forking `embedded-hal` or by creating a new crate with the intent of integrating this into `embedded-hal` once the traits have stabilized. You may find [cargo workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) and [patch](https://doc.rust-lang.org/edition-guide/rust-2018/cargo-and-crates-io/replacing-dependencies-with-patch.html) useful for the forking approach.
+
+Traits should be demonstrated with at least *two* implementations on different platforms and *one* generic driver built on the trait. Where it is possible we suggest an implementation on a microcontroller, and implementation for [linux](https://github.com/rust-embedded/linux-embedded-hal), and a driver (or drivers where requirements are more complex) with bounds using the trait.
+
+## Proposing a trait
+
+Once the trait has been demonstrated a PR should be opened to merge the new trait(s) into `embedded-hal`. This should include a link to the previous discussion issue.
+
+If there is determined to be more than one alternative then there should be further discussion to
+try to single out the best option. Once there is consensus this will be merged into the `embedded-hal` repository.
+
+These issues / PRs will be labeled as `proposal`s in the issue tracker.

--- a/docs/msrv.md
+++ b/docs/msrv.md
@@ -13,6 +13,8 @@ We follow these rules when upgrading it:
 
 - We will not update the MSRV on any patch release: \_.\_.*Z*.
 - We may upgrade the MSRV on any *major* or *minor* release: *X*.*Y*.\_.
+- We may upgrade the MSRV in any preliminary version release (e.g. an `-alpha` release) as
+  these serve as preparation for the final release.
 - MSRV upgrades will be clearly stated in the changelog.
 
 This applies both to `0._._` releases as well as `>=1._._` releases.

--- a/docs/msrv.md
+++ b/docs/msrv.md
@@ -1,0 +1,28 @@
+# Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on all stable Rust versions going back to
+the version stated as MSRV in the README. It *might* compile with even older versions but
+that may change in any new patch release.
+
+## How the MSRV will be upgraded
+
+For `embedded-hal`, we do not consider upgrading the MSRV a strictly breaking change as defined by
+[SemVer](https://semver.org).
+
+We follow these rules when upgrading it:
+
+- We will not update the MSRV on any patch release: \_.\_.*Z*.
+- We may upgrade the MSRV on any *major* or *minor* release: *X*.*Y*.\_.
+- MSRV upgrades will be clearly stated in the changelog.
+
+This applies both to `0._._` releases as well as `>=1._._` releases.
+
+For example:
+
+For a given `x.y.z` release, we may upgrade the MSRV on `x` and `y` releases but not on `z` releases.
+
+If your MSRV upgrade policy differs from this, you are advised to specify the
+`embedded-hal` dependency in your `Cargo.toml` accordingly.
+
+See the [Rust Embedded Working Group MSRV RFC](https://github.com/rust-embedded/wg/blob/master/rfcs/0523-msrv-2020.md)
+for more background information and reasoning.

--- a/docs/version-policy.md
+++ b/docs/version-policy.md
@@ -1,0 +1,26 @@
+# Version policy
+
+At the moment we are working towards a `1.0.0` release (see [#177]). During this process we will
+release alpha versions like `1.0.0-alpha.1` and `1.0.0-alpha.2`.
+Alpha releases are **not guaranteed** to be compatible with each other.
+They are provided as early previews for community testing and preparation for the final release.
+If you use an alpha release, we recommend you choose an exact version specification in your
+`Cargo.toml` like: `embedded-hal = "=1.0.0-alpha.2"`
+
+See below for a way to implement both an `embedded-hal` `0.2.x` version and an `-alpha` version
+side by side in a HAL.
+
+[#177]: https://github.com/rust-embedded/embedded-hal/issues/177
+
+## Supporting different (alpha and non-alpha) HALs
+
+[embedded-hal-compat](https://github.com/ryankurte/embedded-hal-compat) provides shims
+to support interoperability between the latest `0.2.x` and `1.0.0-alpha.N` HALs, allowing one to use
+incompatible HAL components (generally) without alteration.
+See the [docs](https://docs.rs/embedded-hal-compat/) for examples.
+
+It is also possible for HAL implementations to support both the latest `0.2.x` and `1.0.0-alpha.N` versions
+side by side, for an example see [LPC8xx HAL](https://github.com/lpc-rs/lpc8xx-hal).
+
+Note that `embedded-hal` `-alpha` versions are a moving target and _not guaranteed_ to be compatible.
+Because of this we only aim to support the latest `-alpha`.


### PR DESCRIPTION
I moved some of the sections in the README out into separate documents in a `docs` folder.
I have left the section about alpha releases in there, though. I think it is important enough to grant it its placement.
I have added a document describing a policy to upgrade the MSRV, since this will eventually be important once we have released the `1.0.0` version.

TL;DR: The MSRV may be updated in major or minor releases but not on patch releases.

Closes #364 
