### PR TITLE
async: update to new location of where clause.

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
           components: rustfmt
       - uses: actions-rs/cargo@v1

--- a/embedded-hal-async/src/delay.rs
+++ b/embedded-hal-async/src/delay.rs
@@ -32,19 +32,13 @@ where
 {
     type Error = T::Error;
 
-    type DelayUsFuture<'a>
-    where
-        Self: 'a,
-    = T::DelayUsFuture<'a>;
+    type DelayUsFuture<'a> = T::DelayUsFuture<'a> where Self: 'a;
 
     fn delay_us(&mut self, us: u32) -> Self::DelayUsFuture<'_> {
         T::delay_us(self, us)
     }
 
-    type DelayMsFuture<'a>
-    where
-        Self: 'a,
-    = T::DelayMsFuture<'a>;
+    type DelayMsFuture<'a> = T::DelayMsFuture<'a> where Self: 'a;
 
     fn delay_ms(&mut self, ms: u32) -> Self::DelayMsFuture<'_> {
         T::delay_ms(self, ms)

--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -133,28 +133,19 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
 }
 
 impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
-    type ReadFuture<'a>
-    where
-        Self: 'a,
-    = T::ReadFuture<'a>;
+    type ReadFuture<'a> = T::ReadFuture<'a> where Self: 'a;
 
     fn read<'a>(&'a mut self, address: A, buffer: &'a mut [u8]) -> Self::ReadFuture<'a> {
         T::read(self, address, buffer)
     }
 
-    type WriteFuture<'a>
-    where
-        Self: 'a,
-    = T::WriteFuture<'a>;
+    type WriteFuture<'a> = T::WriteFuture<'a> where Self: 'a;
 
     fn write<'a>(&'a mut self, address: A, bytes: &'a [u8]) -> Self::WriteFuture<'a> {
         T::write(self, address, bytes)
     }
 
-    type WriteReadFuture<'a>
-    where
-        Self: 'a,
-    = T::WriteReadFuture<'a>;
+    type WriteReadFuture<'a> = T::WriteReadFuture<'a> where Self: 'a;
 
     fn write_read<'a>(
         &'a mut self,
@@ -165,11 +156,7 @@ impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
         T::write_read(self, address, bytes, buffer)
     }
 
-    type TransactionFuture<'a, 'b>
-    where
-        Self: 'a,
-        'b: 'a,
-    = T::TransactionFuture<'a, 'b>;
+    type TransactionFuture<'a, 'b> = T::TransactionFuture<'a, 'b> where Self: 'a, 'b: 'a;
 
     fn transaction<'a, 'b>(
         &'a mut self,


### PR DESCRIPTION
Latest nightly changed the location of the `where` clause on impls with GATs:
https://github.com/rust-lang/rust/issues/89122