### PR TITLE
Prepare 1.0.0-alpha.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v1.0.0-alpha.8] - 2022-04-15
+
+*** This is (also) an alpha release with breaking changes (sorry) ***
+
 ### Changed
 - The Minimum Supported Rust Version (MSRV) is now 1.54.0
 - `spi`: unify all traits into `SpiReadBus`, `SpiWriteBus` and `SpiBus` (read-write).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 
 [dependencies]
 nb = "1"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ release alpha versions like `1.0.0-alpha.1` and `1.0.0-alpha.2`.
 Alpha releases are **not guaranteed** to be compatible with each other.
 They are provided as early previews for community testing and preparation for the final release.
 If you use an alpha release, we recommend you choose an exact version specification in your
-`Cargo.toml` like: `embedded-hal = "=1.0.0-alpha.2"`
+`Cargo.toml` like: `embedded-hal = "=1.0.0-alpha.8"`
 
 See [this guide](docs/version-policy.md) for a way to implement both an `embedded-hal` `0.2.x`
 version and an `-alpha` version side by side in a HAL.

--- a/embedded-hal-async/Cargo.toml
+++ b/embedded-hal-async/Cargo.toml
@@ -14,4 +14,4 @@ repository = "https://github.com/rust-embedded/embedded-hal"
 version = "0.0.1"
 
 [dependencies]
-embedded-hal = { version = "=1.0.0-alpha.7", path = ".." }
+embedded-hal = { version = "=1.0.0-alpha.8", path = ".." }


### PR DESCRIPTION
Even though the I2C rework similar to SPI is not available, it would be good to start gathering some experiences.
This release is a requirement for an initial alpha release of `embedded-hal-async`.