### PR TITLE
Prepare e-h-async 0.1.0-alpha.0 release

### DIFF
--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -4,3 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+## [v0.1.0-alpha.0] - 2022-04-17
+
+First release to crates.io
+
+
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.1.0-alpha.0...HEAD
+[v0.1.0-alpha.0]: https://github.com/rust-embedded/embedded-hal/tree/embedded-hal-async-v0.1.0-alpha.0

--- a/embedded-hal-async/Cargo.toml
+++ b/embedded-hal-async/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal-async"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "0.0.1"
+version = "0.1.0-alpha.0"
 
 [dependencies]
 embedded-hal = { version = "=1.0.0-alpha.8", path = ".." }


### PR DESCRIPTION
Since it is based on an `embedded-hal` alpha release, it seems appropriate for it to also be an alpha release.