### PR TITLE
async: remove useless `+ 'a` in TAITs.

### DIFF
--- a/embedded-hal-async/src/delay.rs
+++ b/embedded-hal-async/src/delay.rs
@@ -8,7 +8,7 @@ pub trait DelayUs {
     type Error: core::fmt::Debug;
 
     /// The future returned by the `delay_us` function.
-    type DelayUsFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type DelayUsFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -17,7 +17,7 @@ pub trait DelayUs {
     fn delay_us(&mut self, us: u32) -> Self::DelayUsFuture<'_>;
 
     /// The future returned by the `delay_ms` function.
-    type DelayMsFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type DelayMsFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 

--- a/embedded-hal-async/src/digital.rs
+++ b/embedded-hal-async/src/digital.rs
@@ -21,7 +21,7 @@ use core::future::Future;
 /// Asynchronously wait for GPIO pin state.
 pub trait Wait: embedded_hal::digital::ErrorType {
     /// The future returned by the `wait_for_high` function.
-    type WaitForHighFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type WaitForHighFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -33,7 +33,7 @@ pub trait Wait: embedded_hal::digital::ErrorType {
     fn wait_for_high<'a>(&'a mut self) -> Self::WaitForHighFuture<'a>;
 
     /// The future returned by `wait_for_low`.
-    type WaitForLowFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type WaitForLowFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -45,7 +45,7 @@ pub trait Wait: embedded_hal::digital::ErrorType {
     fn wait_for_low<'a>(&'a mut self) -> Self::WaitForLowFuture<'a>;
 
     /// The future returned from `wait_for_rising_edge`.
-    type WaitForRisingEdgeFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type WaitForRisingEdgeFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -56,7 +56,7 @@ pub trait Wait: embedded_hal::digital::ErrorType {
     fn wait_for_rising_edge<'a>(&'a mut self) -> Self::WaitForRisingEdgeFuture<'a>;
 
     /// The future returned from `wait_for_falling_edge`.
-    type WaitForFallingEdgeFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type WaitForFallingEdgeFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -67,7 +67,7 @@ pub trait Wait: embedded_hal::digital::ErrorType {
     fn wait_for_falling_edge<'a>(&'a mut self) -> Self::WaitForFallingEdgeFuture<'a>;
 
     /// The future returned from `wait_for_any_edge`.
-    type WaitForAnyEdgeFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type WaitForAnyEdgeFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 

--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -25,7 +25,7 @@ pub use embedded_hal::i2c::{
 /// Async i2c
 pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// Future returned by the `read` method.
-    type ReadFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type ReadFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -50,7 +50,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     fn read<'a>(&'a mut self, address: A, read: &'a mut [u8]) -> Self::ReadFuture<'a>;
 
     /// Future returned by the `write` method.
-    type WriteFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type WriteFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -73,7 +73,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     fn write<'a>(&'a mut self, address: A, write: &'a [u8]) -> Self::WriteFuture<'a>;
 
     /// Future returned by the `write_read` method.
-    type WriteReadFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type WriteReadFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -107,7 +107,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     ) -> Self::WriteReadFuture<'a>;
 
     /// Future returned by the `transaction` method.
-    type TransactionFuture<'a, 'b>: Future<Output = Result<(), Self::Error>> + 'a
+    type TransactionFuture<'a, 'b>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a,
         'b: 'a;

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -46,7 +46,7 @@ pub trait SpiDevice: ErrorType {
     type Bus: ErrorType;
 
     /// Future returned by the `transaction` method.
-    type TransactionFuture<'a, R, F, Fut>: Future<Output = Result<R, Self::Error>> + 'a
+    type TransactionFuture<'a, R, F, Fut>: Future<Output = Result<R, Self::Error>>
     where
         Self: 'a,
         R: 'a,
@@ -170,7 +170,7 @@ impl<T: SpiDevice> SpiDevice for &mut T {
 /// Flush support for SPI bus
 pub trait SpiBusFlush: ErrorType {
     /// Future returned by the `flush` method.
-    type FlushFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type FlushFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -191,7 +191,7 @@ impl<T: SpiBusFlush> SpiBusFlush for &mut T {
 /// Read-only SPI bus
 pub trait SpiBusRead<Word: 'static + Copy = u8>: SpiBusFlush {
     /// Future returned by the `read` method.
-    type ReadFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type ReadFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -216,7 +216,7 @@ impl<T: SpiBusRead<Word>, Word: 'static + Copy> SpiBusRead<Word> for &mut T {
 /// Write-only SPI
 pub trait SpiBusWrite<Word: 'static + Copy = u8>: SpiBusFlush {
     /// Future returned by the `write` method.
-    type WriteFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type WriteFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -242,7 +242,7 @@ impl<T: SpiBusWrite<Word>, Word: 'static + Copy> SpiBusWrite<Word> for &mut T {
 /// See (the docs on embedded-hal)[embedded_hal::spi::blocking] for important information on SPI Bus vs Device traits.
 pub trait SpiBus<Word: 'static + Copy = u8>: SpiBusRead<Word> + SpiBusWrite<Word> {
     /// Future returned by the `transfer` method.
-    type TransferFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type TransferFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -264,7 +264,7 @@ pub trait SpiBus<Word: 'static + Copy = u8>: SpiBusRead<Word> + SpiBusWrite<Word
     ) -> Self::TransferFuture<'a>;
 
     /// Future returned by the `transfer_in_place` method.
-    type TransferInPlaceFuture<'a>: Future<Output = Result<(), Self::Error>> + 'a
+    type TransferInPlaceFuture<'a>: Future<Output = Result<(), Self::Error>>
     where
         Self: 'a;
 
@@ -381,7 +381,7 @@ where
 {
     type Bus = BUS;
 
-    type TransactionFuture<'a, R, F, Fut> = impl Future<Output = Result<R, Self::Error>> + 'a
+    type TransactionFuture<'a, R, F, Fut> = impl Future<Output = Result<R, Self::Error>>
     where
         Self: 'a, R: 'a, F: FnOnce(*mut Self::Bus) -> Fut + 'a,
         Fut: Future<Output =  Result<R, <Self::Bus as ErrorType>::Error>> + 'a;


### PR DESCRIPTION
These aren't needed, they're already implied by the type having `'a` as a generic param.