### PR TITLE
Make `can::Id` usable as key in `BTreeMap` and `HashMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
 - Implement `PartialOrd`, `Ord`, `Hash` for `can::StandardId`, `can::ExtendedId` and `can::Id` according to CAN bus arbitration rules
 
 ## [v1.0.0-alpha.8] - 2022-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Implement `PartialOrd`, `Ord`, `Hash` for `can::StandardId`, `can::ExtendedId` and `can::Id` according to CAN bus arbitration rules
+
 ## [v1.0.0-alpha.8] - 2022-04-15
 
 *** This is (also) an alpha release with breaking changes (sorry) ***

--- a/src/can/id.rs
+++ b/src/can/id.rs
@@ -183,16 +183,6 @@ mod tests {
     }
 
     #[test]
-    fn cmp_standard() {
-        assert!(StandardId::MAX < StandardId::ZERO);
-    }
-
-    #[test]
-    fn cmp_extended() {
-        assert!(ExtendedId::MAX < ExtendedId::ZERO);
-    }
-
-    #[test]
     fn cmp_id() {
         assert!(StandardId::ZERO < StandardId::MAX);
         assert!(ExtendedId::ZERO < ExtendedId::MAX);

--- a/src/can/id.rs
+++ b/src/can/id.rs
@@ -194,7 +194,12 @@ mod tests {
 
     #[test]
     fn cmp_id() {
-        assert!(Id::Standard(StandardId::MAX) < Id::Standard(StandardId::ZERO));
-        assert!(Id::Extended(ExtendedId::MAX) < Id::Extended(ExtendedId::ZERO));
+        assert!(StandardId::ZERO < StandardId::MAX);
+        assert!(ExtendedId::ZERO < ExtendedId::MAX);
+
+        assert!(Id::Standard(StandardId::ZERO) < Id::Extended(ExtendedId::ZERO));
+        assert!(Id::Extended(ExtendedId::ZERO) < Id::Extended(ExtendedId::MAX));
+        assert!(Id::Extended(ExtendedId((1 << 11) - 1)) < Id::Standard(StandardId(1)));
+        assert!(Id::Standard(StandardId(1)) < Id::Extended(ExtendedId::MAX));
     }
 }

--- a/src/can/id.rs
+++ b/src/can/id.rs
@@ -94,6 +94,20 @@ pub enum Id {
     Extended(ExtendedId),
 }
 
+/// Implement `Ord` according to the CAN arbitration rules
+///
+/// When performing arbitration, frames are looked at bit for bit starting
+/// from the beginning. A bit with the value 0 is dominant and a bit with
+/// value of 1 is recessive.
+///
+/// When two devices are sending frames at the same time, as soon as the first
+/// bit is found which differs, the frame with the corresponding dominant
+/// 0 bit will win and get to send the rest of the frame.
+///
+/// This implementation of `Ord` for `Id` will take this into consideration
+/// and when comparing two different instances of `Id` the "smallest" will
+/// always be the id which would form the most dominant frame, all other
+/// things being equal.
 impl Ord for Id {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         let split_id = |id: &Id| {

--- a/src/can/id.rs
+++ b/src/can/id.rs
@@ -1,7 +1,7 @@
 //! CAN Identifiers.
 
 /// Standard 11-bit CAN Identifier (`0..=0x7FF`).
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct StandardId(u16);
 
 impl StandardId {
@@ -40,7 +40,7 @@ impl StandardId {
 }
 
 /// Extended 29-bit CAN Identifier (`0..=1FFF_FFFF`).
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct ExtendedId(u32);
 
 impl ExtendedId {
@@ -85,7 +85,7 @@ impl ExtendedId {
 }
 
 /// A CAN Identifier (standard or extended).
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub enum Id {
     /// Standard 11-bit Identifier (`0..=0x7FF`).
     Standard(StandardId),

--- a/src/can/id.rs
+++ b/src/can/id.rs
@@ -106,7 +106,7 @@ pub enum Id {
 ///
 /// This implementation of `Ord` for `Id` will take this into consideration
 /// and when comparing two different instances of `Id` the "smallest" will
-/// always be the id which would form the most dominant frame, all other
+/// always be the ID which would form the most dominant frame, all other
 /// things being equal.
 impl Ord for Id {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {


### PR DESCRIPTION
Implement `Ord` and `Hash` for `can::Id` to make it usable as key in `BTreeMap` and `HashMap`