### PR TITLE
[Proposal] I2S traits - take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- I2S traits
+
 ## [v1.0.0-alpha.8] - 2022-04-15
 
 *** This is (also) an alpha release with breaking changes (sorry) ***

--- a/src/i2s.rs
+++ b/src/i2s.rs
@@ -1,0 +1,35 @@
+//! I2S API
+
+/// Blocking I2S traits
+pub mod blocking {
+
+    /// Blocking I2S trait
+    pub trait I2s<W> {
+        /// Error type
+        type Error: core::fmt::Debug;
+
+        /// Reads enough bytes to fill `left_words` and `right_words`.
+        fn read<'w>(
+            &mut self,
+            left_words: &'w mut [W],
+            right_words: &'w mut [W],
+        ) -> Result<(), Self::Error>;
+
+        /// Sends `left_words` and `right_words`.
+        fn write<'w>(
+            &mut self,
+            left_words: &'w [W],
+            right_words: &'w [W],
+        ) -> Result<(), Self::Error>;
+
+        /// Sends `left_words` and `right_words`.
+        fn write_iter<LW, RW>(
+            &mut self,
+            left_words: LW,
+            right_words: RW,
+        ) -> Result<(), Self::Error>
+        where
+            LW: IntoIterator<Item = W>,
+            RW: IntoIterator<Item = W>;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,6 +359,7 @@ pub mod can;
 pub mod delay;
 pub mod digital;
 pub mod i2c;
+pub mod i2s;
 pub mod serial;
 pub mod spi;
 


### PR DESCRIPTION
_(This was all done and discussed in #204 but this crate continued its evolution before the merge. Here I just adapted the traits to how we do things now: 1 blocking trait with all methods, no `nb` variant as that will be deprecated eventually.
The proof implementations need to be adapted (sorry!) but this should be pretty easy)_

I added some I2S traits to kick off the discussion started in #203.
The traits accept two words for left and right and are otherwise similar to SPI as of the 0.2.x version.

An interleaved version can be found in the [`i2s-interleaved`](https://github.com/eldruin/embedded-hal/tree/i2s-interleaved) branch. There the data should be passed interleaved. e.g. `[left0,right0,left1,right1,...]`

A version of these traits for the embedded-hal 0.2.x version can be found in the [`i2s-v0.2.x`](https://github.com/eldruin/embedded-hal/tree/i2s-v0.2.x) branch.

There is another MCU implementation in [`stm32f4xx-hal`](https://github.com/stm32-rs/stm32f4xx-hal/pull/265)

TODO:
- [ ] Demo microcontroller HAL implementation:
    - [ ] [stm32h7xx-hal](https://github.com/stm32-rs/stm32h7xx-hal/pull/99) - [discussion issue](https://github.com/stm32-rs/stm32h7xx-hal/issues/90)
    - [ ] [[WIP] stm32f4xx-hal](https://github.com/stm32-rs/stm32f4xx-hal/pull/145)
- [ ] [Bit-banging HAL implementation supporting 16-bit and 32-bit packets](https://github.com/eldruin/bitbang-hal/blob/i2s-v0.2.x/src/i2s.rs)
    - [ ] [Working example tested using both MAX98357A and PCM5102A](https://github.com/eldruin/driver-examples/blob/i2s-bitbang-bp/stm32f1-bluepill/examples/i2s-audio-bitbang.rs)
- [ ] [Working example of saw wave](https://github.com/maxekman/stm32f407g-disc/blob/dac-support-with-cs43l22/examples/audio.rs)
    - Uses driver: https://github.com/maxekman/cs43l22
- [ ] Full-duplex trait implementation
    - [ ] [stm32h7xx-hal](https://github.com/stm32-rs/stm32h7xx-hal/pull/99) - [discussion issue](https://github.com/stm32-rs/stm32h7xx-hal/issues/90)
- [X] Changelog entry.
- [ ] Add documentation about what happens if the buffer sizes differ.

Thoughts?
cc. @maxekman @samcrow @YruamaLairba