### PR TITLE
Change missing_docs from deny to warn.

### DIFF
--- a/embedded-hal-async/src/lib.rs
+++ b/embedded-hal-async/src/lib.rs
@@ -7,7 +7,7 @@
 //! **NOTE** The traits and modules in this crate should follow the same structure as in
 //! `embedded-hal` to ease merging and migration.
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 #![no_std]
 #![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@
 //! # fn main() {}
 //! ```
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 #![no_std]
 
 pub mod fmt;


### PR DESCRIPTION
It is annoying to get hard errors while developing, it prevents testing things out
without documenting them because it fails the build.

This changes it to warn, which has the same effect in CI (because it already has `RUSTFLAGS: '--deny warnings'`),
but still allows buildilng.