### PR TITLE
Add I2C `software_reset` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Implement `PartialOrd`, `Ord`, `Hash` for `can::StandardId`, `can::ExtendedId` and `can::Id` according to CAN bus arbitration rules
+- `I2c::software_reset` for resetting all (supported) devices connected to the bus.
 
 ### Fixed
 - Fixed documentation for `wait_for_rising_edge`.

--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.1.0-alpha.1] - 2022-05-24
 
+### Added
+
+- `I2c::software_reset` for resetting all (supported) devices connected to the bus.
+
 ### Changed
 
 - spi: device helper methods (`read`, `write`, `transfer`...) are now default methods in `SpiDevice` instead of an `SpiDeviceExt` extension trait.

--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -130,6 +130,16 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
         address: A,
         operations: &'a mut [Operation<'b>],
     ) -> Self::TransactionFuture<'a, 'b>;
+
+    /// Request a software reset for all devices connected to the I2C bus.
+    ///
+    /// # Note
+    ///
+    /// This I2C feature is optional. It depends on each individual device whether or not it responds to this command.
+    #[inline]
+    fn software_reset<'a>(&'a mut self) -> Self::WriteFuture<'a> {
+        self.write(A::GENERAL_CALL_ADDR, &[0x06])
+    }
 }
 
 impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,11 +361,3 @@ pub mod digital;
 pub mod i2c;
 pub mod serial;
 pub mod spi;
-
-mod private {
-    use crate::i2c::{SevenBitAddress, TenBitAddress};
-    pub trait Sealed {}
-
-    impl Sealed for SevenBitAddress {}
-    impl Sealed for TenBitAddress {}
-}


### PR DESCRIPTION
Add method for software reset via the “General Call” address.