### PR TITLE
async/spi: Add a transaction helper macro

### DIFF
--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - spi: device helper methods (`read`, `write`, `transfer`...) are now default methods in `SpiDevice` instead of an `SpiDeviceExt` extension trait.
 - spi: the `SpiDevice::transaction` closure now gets a raw pointer to the `SpiBus` to work around Rust borrow checker limitations.
+- spi: the `SpiDevice` trait is now unsafe to implement due to the raw pointer workaround.
 
 
 ## [v0.1.0-alpha.0] - 2022-04-17

--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.1.0-alpha.1] - 2022-05-24
 
+### Added
+
+- spi: added a transaction helper macro as a workaround for the raw pointer workaround.
+
 ### Changed
 
 - spi: device helper methods (`read`, `write`, `transfer`...) are now default methods in `SpiDevice` instead of an `SpiDeviceExt` extension trait.

--- a/embedded-hal-async/src/lib.rs
+++ b/embedded-hal-async/src/lib.rs
@@ -9,7 +9,6 @@
 
 #![warn(missing_docs)]
 #![no_std]
-#![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
 pub mod delay;

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -59,6 +59,24 @@ where
 ///     .await
 /// }
 /// ```
+///
+/// Note that the compiler will prevent you from moving the bus reference outside of the closure
+/// ```compile_fail
+/// # use embedded_hal_async::spi::{transaction_helper, SpiBus, SpiBusRead, SpiBusWrite, SpiDevice};
+/// #
+/// # pub async fn smuggle_test<SPI>(mut device: SPI) -> Result<(), SPI::Error>
+/// # where
+/// #     SPI: SpiDevice,
+/// #     SPI::Bus: SpiBus,
+/// # {
+///     let mut bus_smuggler: Option<&mut SPI::Bus> = None;
+///     transaction_helper!(&mut device, move |bus| async move {
+///         bus_smuggler = Some(bus);
+///         Ok(())
+///     })
+///     .await
+/// # }
+/// ```
 macro_rules! spi_transaction_helper {
     ($device:expr, move |$bus:ident| async move $closure_body:expr) => {
         $crate::spi::SpiDevice::transaction($device, move |$bus| {

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -36,7 +36,8 @@ where
 = impl Future<Output = Result<(), T::Error>>;
 
 #[macro_export]
-/// This macro is a workaround for the workaround in [`SpiDevice::transaction`]
+/// Do an SPI transaction on a bus.
+/// This is a safe wrapper for [SpiDevice::transaction], which handles dereferencing the raw pointer for you.
 ///
 /// # Examples
 ///

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -163,7 +163,7 @@ pub unsafe trait SpiDevice: ErrorType {
     /// **NOTE:**
     /// It is not recommended to use this method directly, because it requires `unsafe` code to dereference the raw pointer.
     /// Instead, the [`transaction!`] macro should be used, which handles this safely inside the macro.
-    /// 
+    ///
     /// - Locks the bus
     /// - Asserts the CS (Chip Select) pin.
     /// - Calls `f` with an exclusive reference to the bus, which can then be used to do transfers against the device.

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -91,6 +91,45 @@ macro_rules! spi_transaction_helper {
             }
         })
     };
+    ($device:expr, move |$bus:ident| async $closure_body:expr) => {
+        $crate::spi::SpiDevice::transaction($device, move |$bus| {
+            // Safety: Implementers of the `SpiDevice` trait guarantee that the pointer is
+            // valid and dereferencable for the entire duration of the closure.
+            let $bus = unsafe { &mut *$bus };
+            async {
+                let result = $closure_body;
+                let $bus = $bus; // Ensure that the bus reference was not moved out of the closure
+                let _ = $bus; // Silence the "unused variable" warning from prevous line
+                result
+            }
+        })
+    };
+    ($device:expr, |$bus:ident| async move $closure_body:expr) => {
+        $crate::spi::SpiDevice::transaction($device, |$bus| {
+            // Safety: Implementers of the `SpiDevice` trait guarantee that the pointer is
+            // valid and dereferencable for the entire duration of the closure.
+            let $bus = unsafe { &mut *$bus };
+            async move {
+                let result = $closure_body;
+                let $bus = $bus; // Ensure that the bus reference was not moved out of the closure
+                let _ = $bus; // Silence the "unused variable" warning from prevous line
+                result
+            }
+        })
+    };
+    ($device:expr, |$bus:ident| async $closure_body:expr) => {
+        $crate::spi::SpiDevice::transaction($device, |$bus| {
+            // Safety: Implementers of the `SpiDevice` trait guarantee that the pointer is
+            // valid and dereferencable for the entire duration of the closure.
+            let $bus = unsafe { &mut *$bus };
+            async {
+                let result = $closure_body;
+                let $bus = $bus; // Ensure that the bus reference was not moved out of the closure
+                let _ = $bus; // Silence the "unused variable" warning from prevous line
+                result
+            }
+        })
+    };
 }
 
 #[doc(inline)]

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -66,7 +66,8 @@ macro_rules! spi_transaction_helper {
             // valid and dereferencable for the entire duration of the closure.
             let $bus = unsafe { &mut *$bus };
             let result = $closure_body;
-            ::core::mem::drop($bus); // Ensure that the bus reference was not moved out of the closure
+            let $bus = $bus; // Ensure that the bus reference was not moved out of the closure
+            let _ = $bus; // Silence the "unused variable" warning from prevous line
             result
         })
     };

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -61,14 +61,16 @@ where
 /// ```
 macro_rules! spi_transaction_helper {
     ($device:expr, move |$bus:ident| async move $closure_body:expr) => {
-        $crate::spi::SpiDevice::transaction($device, move |$bus| async move {
+        $crate::spi::SpiDevice::transaction($device, move |$bus| {
             // Safety: Implementers of the `SpiDevice` trait guarantee that the pointer is
             // valid and dereferencable for the entire duration of the closure.
             let $bus = unsafe { &mut *$bus };
-            let result = $closure_body;
-            let $bus = $bus; // Ensure that the bus reference was not moved out of the closure
-            let _ = $bus; // Silence the "unused variable" warning from prevous line
-            result
+            async move {
+                let result = $closure_body;
+                let $bus = $bus; // Ensure that the bus reference was not moved out of the closure
+                let _ = $bus; // Silence the "unused variable" warning from prevous line
+                result
+            }
         })
     };
 }

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -160,6 +160,10 @@ pub unsafe trait SpiDevice: ErrorType {
 
     /// Perform a transaction against the device.
     ///
+    /// **NOTE:**
+    /// It is not recommended to use this method directly, because it requires `unsafe` code to dereference the raw pointer.
+    /// Instead, the [`transaction!`] macro should be used, which handles this safely inside the macro.
+    /// 
     /// - Locks the bus
     /// - Asserts the CS (Chip Select) pin.
     /// - Calls `f` with an exclusive reference to the bus, which can then be used to do transfers against the device.


### PR DESCRIPTION
Based on #403

This macro allows users to use `SpiDevice::transaction` in a completely safe way, without needing to dereference a raw pointer.

The macro is exported as `embedded_hal_async::spi_transaction_helper` because exported macros always go in the root of the crate.
It is also publicly reexported as `embedded_hal_async::spi::transaction_helper` because I think that most people would expect to find it in the spi module.
It is not possible to apply `doc(hidden)` to the instance in the root of the crate because that would also hide the reexport, see rust-lang/rust#59368.