### PR TITLE
Enforce clippy in CI

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -11,5 +11,6 @@ status = [
   "test (nightly, x86_64-unknown-linux-gnu)",
   "test (nightly, thumbv6m-none-eabi)",
   "test (nightly, thumbv7m-none-eabi)",
+  "clippy",
   "fmt",
 ]

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -14,9 +14,7 @@ jobs:
           profile: minimal
           # embedded-hal-async needs nightly.
           # Use a pinned version to avoid spontaneous breakages (new clippy lints are added often)
-          toolchain: nightly-2022-09-05  
+          toolchain: nightly-2022-09-25
           override: true
           components: clippy
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo clippy -- --deny=warnings

--- a/embedded-hal-async/src/digital.rs
+++ b/embedded-hal-async/src/digital.rs
@@ -30,7 +30,7 @@ pub trait Wait: embedded_hal::digital::ErrorType {
     /// # Note for implementers
     /// The pin may have switched back to low before the task was run after
     /// being woken. The future should still resolve in that case.
-    fn wait_for_high<'a>(&'a mut self) -> Self::WaitForHighFuture<'a>;
+    fn wait_for_high(&mut self) -> Self::WaitForHighFuture<'_>;
 
     /// The future returned by `wait_for_low`.
     type WaitForLowFuture<'a>: Future<Output = Result<(), Self::Error>>
@@ -42,7 +42,7 @@ pub trait Wait: embedded_hal::digital::ErrorType {
     /// # Note for implementers
     /// The pin may have switched back to high before the task was run after
     /// being woken. The future should still resolve in that case.
-    fn wait_for_low<'a>(&'a mut self) -> Self::WaitForLowFuture<'a>;
+    fn wait_for_low(&mut self) -> Self::WaitForLowFuture<'_>;
 
     /// The future returned from `wait_for_rising_edge`.
     type WaitForRisingEdgeFuture<'a>: Future<Output = Result<(), Self::Error>>
@@ -53,7 +53,7 @@ pub trait Wait: embedded_hal::digital::ErrorType {
     ///
     /// If the pin is already high, this does *not* return immediately, it'll wait for the
     /// pin to go low and then high again.
-    fn wait_for_rising_edge<'a>(&'a mut self) -> Self::WaitForRisingEdgeFuture<'a>;
+    fn wait_for_rising_edge(&mut self) -> Self::WaitForRisingEdgeFuture<'_>;
 
     /// The future returned from `wait_for_falling_edge`.
     type WaitForFallingEdgeFuture<'a>: Future<Output = Result<(), Self::Error>>
@@ -64,7 +64,7 @@ pub trait Wait: embedded_hal::digital::ErrorType {
     ///
     /// If the pin is already low, this does *not* return immediately, it'll wait for the
     /// pin to go high and then low again.
-    fn wait_for_falling_edge<'a>(&'a mut self) -> Self::WaitForFallingEdgeFuture<'a>;
+    fn wait_for_falling_edge(&mut self) -> Self::WaitForFallingEdgeFuture<'_>;
 
     /// The future returned from `wait_for_any_edge`.
     type WaitForAnyEdgeFuture<'a>: Future<Output = Result<(), Self::Error>>
@@ -72,37 +72,37 @@ pub trait Wait: embedded_hal::digital::ErrorType {
         Self: 'a;
 
     /// Wait for the pin to undergo any transition, i.e low to high OR high to low.
-    fn wait_for_any_edge<'a>(&'a mut self) -> Self::WaitForAnyEdgeFuture<'a>;
+    fn wait_for_any_edge(&mut self) -> Self::WaitForAnyEdgeFuture<'_>;
 }
 
 impl<T: Wait> Wait for &mut T {
     type WaitForHighFuture<'a> = T::WaitForHighFuture<'a> where Self: 'a;
 
-    fn wait_for_high<'a>(&'a mut self) -> Self::WaitForHighFuture<'a> {
+    fn wait_for_high(&mut self) -> Self::WaitForHighFuture<'_> {
         T::wait_for_high(self)
     }
 
     type WaitForLowFuture<'a> = T::WaitForLowFuture<'a> where Self: 'a;
 
-    fn wait_for_low<'a>(&'a mut self) -> Self::WaitForLowFuture<'a> {
+    fn wait_for_low(&mut self) -> Self::WaitForLowFuture<'_> {
         T::wait_for_low(self)
     }
 
     type WaitForRisingEdgeFuture<'a> = T::WaitForRisingEdgeFuture<'a> where Self: 'a;
 
-    fn wait_for_rising_edge<'a>(&'a mut self) -> Self::WaitForRisingEdgeFuture<'a> {
+    fn wait_for_rising_edge(&mut self) -> Self::WaitForRisingEdgeFuture<'_> {
         T::wait_for_rising_edge(self)
     }
 
     type WaitForFallingEdgeFuture<'a> = T::WaitForFallingEdgeFuture<'a> where Self: 'a;
 
-    fn wait_for_falling_edge<'a>(&'a mut self) -> Self::WaitForFallingEdgeFuture<'a> {
+    fn wait_for_falling_edge(&mut self) -> Self::WaitForFallingEdgeFuture<'_> {
         T::wait_for_falling_edge(self)
     }
 
     type WaitForAnyEdgeFuture<'a> = T::WaitForAnyEdgeFuture<'a> where Self: 'a;
 
-    fn wait_for_any_edge<'a>(&'a mut self) -> Self::WaitForAnyEdgeFuture<'a> {
+    fn wait_for_any_edge(&mut self) -> Self::WaitForAnyEdgeFuture<'_> {
         T::wait_for_any_edge(self)
     }
 }

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -284,13 +284,13 @@ pub trait SpiBusFlush: ErrorType {
     /// Wait until all operations have completed and the bus is idle.
     ///
     /// See (the docs on embedded-hal)[embedded_hal::spi::blocking] for information on flushing.
-    fn flush<'a>(&'a mut self) -> Self::FlushFuture<'a>;
+    fn flush(&mut self) -> Self::FlushFuture<'_>;
 }
 
 impl<T: SpiBusFlush> SpiBusFlush for &mut T {
     type FlushFuture<'a> = T::FlushFuture<'a> where Self: 'a;
 
-    fn flush<'a>(&'a mut self) -> Self::FlushFuture<'a> {
+    fn flush(&mut self) -> Self::FlushFuture<'_> {
         T::flush(self)
     }
 }

--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Implement `PartialOrd`, `Ord`, `Hash` for `can::StandardId`, `can::ExtendedId` and `can::Id` according to CAN bus arbitration rules
+- Implement `Eq` for `i2c::Operaiton`
 
 ### Fixed
 - Fixed documentation for `wait_for_rising_edge`.

--- a/embedded-hal/src/i2c.rs
+++ b/embedded-hal/src/i2c.rs
@@ -259,7 +259,7 @@ impl AddressMode for TenBitAddress {}
 /// Transactional I2C operation.
 ///
 /// Several operations can be combined as part of a transaction.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Operation<'a> {
     /// Read data into the provided buffer
     Read(&'a mut [u8]),


### PR DESCRIPTION
Depends on #394

CI wasn't actually enforcing clippy, because `actions-rs/clippy-check` needs to run as `pull_request_target` to get the token to add the "fancy" comments to the diff. It does nothing when ran as `pull_request`.

`pull_request_target` is troublesome because it uses the yaml from `master` instead of from the PR branch, which means when bumping clippy you don't know whether CI passes until *after* it's merged. I've made it use `cargo clippy` instead, which works on `pull_request`.