### PR TITLE
Prepare embedded-can 0.4.0 release

### DIFF
--- a/embedded-can/CHANGELOG.md
+++ b/embedded-can/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+...
+
+## [v0.4.0] - 2022-09-28
+
+Release of version of the traits extracted from embedded-hal.
+
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-can-v0.4.0...HEAD
+[v0.4.0]: https://github.com/rust-embedded/embedded-hal/tree/embedded-can-v0.4.0

--- a/embedded-can/README.md
+++ b/embedded-can/README.md
@@ -18,7 +18,7 @@ This project is developed and maintained by the [HAL team][https://github.com/ru
 This crate is guaranteed to compile on stable Rust 1.54 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
-See [here](docs/msrv.md) for details on how the MSRV may be upgraded.
+See [here](../docs/msrv.md) for details on how the MSRV may be upgraded.
 
 ## License
 


### PR DESCRIPTION
Is there anything preventing this release?
cc. @timokroeger 