### PR TITLE
Raise MSRV for embedded-hal-async to Rust 1.65.0

### DIFF
--- a/embedded-hal-async/Cargo.toml
+++ b/embedded-hal-async/Cargo.toml
@@ -12,6 +12,7 @@ name = "embedded-hal-async"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
 version = "0.2.0-alpha.0"
+rust-version = "1.65.0"
 
 [dependencies]
 embedded-hal = { version = "=1.0.0-alpha.9", path = "../embedded-hal" }

--- a/embedded-hal-async/README.md
+++ b/embedded-hal-async/README.md
@@ -17,13 +17,13 @@ This project is developed and maintained by the [HAL team](https://github.com/ru
 
 [API reference]: https://docs.rs/embedded-hal-async
 
-<!--
 ## Minimum Supported Rust Version (MSRV)
 
+This crate requires Rust nightly newer than `nightly-2022-11-22`, due to requiring support for
+`async fn` in traits (AFIT), which is not stable yet. 
 
-This crate requires nightly newer than 2022-09-13, but keep in mind nightly can
-break at any time.
--->
+Keep in mind Rust nightlies can make backwards-incompatible changes to unstable features
+at any time.
 
 ## License
 

--- a/embedded-hal-async/README.md
+++ b/embedded-hal-async/README.md
@@ -1,9 +1,6 @@
 [![crates.io](https://img.shields.io/crates/d/embedded-hal-async.svg)](https://crates.io/crates/embedded-hal-async)
 [![crates.io](https://img.shields.io/crates/v/embedded-hal-async.svg)](https://crates.io/crates/embedded-hal-async)
 [![Documentation](https://docs.rs/embedded-hal-async/badge.svg)](https://docs.rs/embedded-hal-async)
-<!--
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.46+-blue.svg)
--->
 
 # `embedded-hal-async`
 
@@ -23,8 +20,9 @@ This project is developed and maintained by the [HAL team](https://github.com/ru
 <!--
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.46 and up. It *might*
-compile with older versions but that may change in any new patch release.
+
+This crate requires nightly newer than 2022-09-13, but keep in mind nightly can
+break at any time.
 -->
 
 ## License


### PR DESCRIPTION
Required for generic_associated_types feature.