### PR TITLE
embedded-hal-async: fix missing link in README

### DIFF
--- a/embedded-hal-async/README.md
+++ b/embedded-hal-async/README.md
@@ -9,7 +9,7 @@
 
 An asynchronous Hardware Abstraction Layer (HAL) for embedded systems.
 
-This crate contains asynchronous versions of the [`embedded-hal`](https://crates.io/crates/embedded-hal) traits and shares its scope and [design goals].
+This crate contains asynchronous versions of the [`embedded-hal`](https://crates.io/crates/embedded-hal) traits and shares its scope and [design goals](https://docs.rs/embedded-hal/latest/embedded_hal/#design-goals).
 The purpose of this crate is to iterate over these trait versions before integrating them into [`embedded-hal`](https://crates.io/crates/embedded-hal).
 
 **NOTE** These traits are still experimental. At least one breaking change to this crate is expected in the future (changing from GATs to `async fn`), but there might be more.


### PR DESCRIPTION
Restored to what it was in bc3fc45bb9d3e3cff0e2b7f9a91673c03c04ab34.