### PR TITLE
ci: Fix embedded-hal-async not being tested.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           override: true
 
       - run: sed -i '/nightly-only/d' Cargo.toml 
-        if: matrix.toolchain != 'nightly'
+        if: matrix.rust != 'nightly'
 
       - run: cargo check --target=${{ matrix.target }}
 


### PR DESCRIPTION
Fixing a somewhat embarrasing mistake causing embedded-hal-async to never be tested even if using nightly.