### PR TITLE
gpio: add ErrorKind.

### DIFF
--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- gpio: add `ErrorKind` enum for consistency with other traits and for future extensibility. No kinds are defined for now.
 
 ## [v1.0.0-alpha.9] - 2022-09-28
 


### PR DESCRIPTION
This adds an `ErrorKind` to the GPIO `Error` associated type, just like all the other drivers. It has just a single `Other` variant for now. 

The reason to have it is future-proofness: Even if we don't have ideas for ErrorKind variants for now, we might have them in the future.

- If we have `ErrorKind`, we can add more variants in the future backwards-compatibly after the 1.0 launch, thanks to `ErrorKind` being marked `#[non_exhaustive]`.
- If we *don't* have `ErrorKind`, adding it in the future would be a breaking change, because HALs would have to add support for it.