### PR TITLE
delay: make infallible.

### DIFF
--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- delay: make infallible.
+
 ## [v0.2.0-alpha.0] - 2022-11-23
 
 - Switch all traits to use [`async_fn_in_trait`](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-nightly.html) (AFIT). Requires `nightly-2022-11-22` or newer.

--- a/embedded-hal-async/src/delay.rs
+++ b/embedded-hal-async/src/delay.rs
@@ -2,29 +2,24 @@
 
 /// Microsecond delay
 pub trait DelayUs {
-    /// Enumeration of errors
-    type Error: core::fmt::Debug;
-
     /// Pauses execution for at minimum `us` microseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
-    async fn delay_us(&mut self, us: u32) -> Result<(), Self::Error>;
+    async fn delay_us(&mut self, us: u32);
 
     /// Pauses execution for at minimum `ms` milliseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
-    async fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error>;
+    async fn delay_ms(&mut self, ms: u32);
 }
 
 impl<T> DelayUs for &mut T
 where
     T: DelayUs,
 {
-    type Error = T::Error;
-
-    async fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+    async fn delay_us(&mut self, us: u32) {
         T::delay_us(self, us).await
     }
 
-    async fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+    async fn delay_ms(&mut self, ms: u32) {
         T::delay_ms(self, ms).await
     }
 }

--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - gpio: add `ErrorKind` enum for consistency with other traits and for future extensibility. No kinds are defined for now.
+- delay: make infallible.
 
 ## [v1.0.0-alpha.9] - 2022-09-28
 

--- a/embedded-hal/src/delay.rs
+++ b/embedded-hal/src/delay.rs
@@ -3,21 +3,16 @@
 /// Microsecond delay
 ///
 pub trait DelayUs {
-    /// Enumeration of `DelayUs` errors
-    type Error: core::fmt::Debug;
-
     /// Pauses execution for at minimum `us` microseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
-    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error>;
+    fn delay_us(&mut self, us: u32);
 
     /// Pauses execution for at minimum `ms` milliseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
-    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+    fn delay_ms(&mut self, ms: u32) {
         for _ in 0..ms {
-            self.delay_us(1000)?;
+            self.delay_us(1000);
         }
-
-        Ok(())
     }
 }
 
@@ -25,13 +20,11 @@ impl<T> DelayUs for &mut T
 where
     T: DelayUs,
 {
-    type Error = T::Error;
-
-    fn delay_us(&mut self, us: u32) -> Result<(), Self::Error> {
+    fn delay_us(&mut self, us: u32) {
         T::delay_us(self, us)
     }
 
-    fn delay_ms(&mut self, ms: u32) -> Result<(), Self::Error> {
+    fn delay_ms(&mut self, ms: u32) {
         T::delay_ms(self, ms)
     }
 }


### PR DESCRIPTION
1.0 alphas have been out for a while, some HALs out there implement it. I haven't seen one with an actual fallible delay.

I know the decision was made to make Delay fallible for consistency, but I think we should make one exception for just this one trait. 