### PR TITLE
I2c: simplify trait.

### DIFF
--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -41,7 +41,10 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `MAK` = master acknowledge
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
-    async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error>;
+    async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
+        self.transaction(address, &mut [Operation::Read(read)])
+            .await
+    }
 
     /// Writes bytes to slave with address `address`
     ///
@@ -59,7 +62,10 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `SAK` = slave acknowledge
     /// - `Bi` = ith byte of data
     /// - `SP` = stop condition
-    async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error>;
+    async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error> {
+        self.transaction(address, &mut [Operation::Write(write)])
+            .await
+    }
 
     /// Writes bytes to slave with address `address` and then reads enough bytes to fill `read` *in a
     /// single transaction*.
@@ -88,7 +94,13 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
         address: A,
         write: &[u8],
         read: &mut [u8],
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), Self::Error> {
+        self.transaction(
+            address,
+            &mut [Operation::Write(write), Operation::Read(read)],
+        )
+        .await
+    }
 
     /// Execute the provided operations on the I2C bus as a single transaction.
     ///

--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -111,21 +111,21 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
 }
 
 impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
-    async fn read(&mut self, address: A, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        T::read(self, address, buffer).await
+    async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
+        T::read(self, address, read).await
     }
 
-    async fn write(&mut self, address: A, bytes: &[u8]) -> Result<(), Self::Error> {
-        T::write(self, address, bytes).await
+    async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error> {
+        T::write(self, address, write).await
     }
 
     async fn write_read(
         &mut self,
         address: A,
-        bytes: &[u8],
-        buffer: &mut [u8],
+        write: &[u8],
+        read: &mut [u8],
     ) -> Result<(), Self::Error> {
-        T::write_read(self, address, bytes, buffer).await
+        T::write_read(self, address, write, read).await
     }
 
     async fn transaction(

--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -41,7 +41,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `MAK` = master acknowledge
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
-    async fn read<'a>(&'a mut self, address: A, read: &'a mut [u8]) -> Result<(), Self::Error>;
+    async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error>;
 
     /// Writes bytes to slave with address `address`
     ///
@@ -59,7 +59,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `SAK` = slave acknowledge
     /// - `Bi` = ith byte of data
     /// - `SP` = stop condition
-    async fn write<'a>(&'a mut self, address: A, write: &'a [u8]) -> Result<(), Self::Error>;
+    async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error>;
 
     /// Writes bytes to slave with address `address` and then reads enough bytes to fill `read` *in a
     /// single transaction*.
@@ -83,11 +83,11 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `MAK` = master acknowledge
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
-    async fn write_read<'a>(
-        &'a mut self,
+    async fn write_read(
+        &mut self,
         address: A,
-        write: &'a [u8],
-        read: &'a mut [u8],
+        write: &[u8],
+        read: &mut [u8],
     ) -> Result<(), Self::Error>;
 
     /// Execute the provided operations on the I2C bus as a single transaction.
@@ -103,35 +103,35 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `SAD+R/W` = slave address followed by bit 1 to indicate reading or 0 to indicate writing
     /// - `SR` = repeated start condition
     /// - `SP` = stop condition
-    async fn transaction<'a, 'b>(
-        &'a mut self,
+    async fn transaction(
+        &mut self,
         address: A,
-        operations: &'a mut [Operation<'b>],
+        operations: &mut [Operation<'_>],
     ) -> Result<(), Self::Error>;
 }
 
 impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
-    async fn read<'a>(&'a mut self, address: A, buffer: &'a mut [u8]) -> Result<(), Self::Error> {
+    async fn read(&mut self, address: A, buffer: &mut [u8]) -> Result<(), Self::Error> {
         T::read(self, address, buffer).await
     }
 
-    async fn write<'a>(&'a mut self, address: A, bytes: &'a [u8]) -> Result<(), Self::Error> {
+    async fn write(&mut self, address: A, bytes: &[u8]) -> Result<(), Self::Error> {
         T::write(self, address, bytes).await
     }
 
-    async fn write_read<'a>(
-        &'a mut self,
+    async fn write_read(
+        &mut self,
         address: A,
-        bytes: &'a [u8],
-        buffer: &'a mut [u8],
+        bytes: &[u8],
+        buffer: &mut [u8],
     ) -> Result<(), Self::Error> {
         T::write_read(self, address, bytes, buffer).await
     }
 
-    async fn transaction<'a, 'b>(
-        &'a mut self,
+    async fn transaction(
+        &mut self,
         address: A,
-        operations: &'a mut [Operation<'b>],
+        operations: &mut [Operation<'_>],
     ) -> Result<(), Self::Error> {
         T::transaction(self, address, operations).await
     }

--- a/embedded-hal/src/i2c.rs
+++ b/embedded-hal/src/i2c.rs
@@ -29,18 +29,6 @@
 //! # impl ErrorType for I2c0 { type Error = ErrorKind; }
 //! impl I2c<SevenBitAddress> for I2c0
 //! {
-//!     fn read(&mut self, addr: u8, read: &mut [u8]) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
-//!     fn write(&mut self, addr: u8, write: &[u8]) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
-//!     fn write_read(&mut self, addr: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
 //!     fn transaction(&mut self, address: u8, operations: &mut [Operation<'_>]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
@@ -49,18 +37,6 @@
 //!
 //! impl I2c<TenBitAddress> for I2c0
 //! {
-//!     fn read(&mut self, addr: u16, write: &mut [u8]) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
-//!     fn write(&mut self, addr: u16, read: &[u8]) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
-//!     fn write_read(&mut self, addr: u16, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
 //!     fn transaction(&mut self, address: u16, operations: &mut [Operation<'_>]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
@@ -232,7 +208,7 @@ impl AddressMode for SevenBitAddress {}
 
 impl AddressMode for TenBitAddress {}
 
-/// Transactional I2C operation.
+/// I2C operation.
 ///
 /// Several operations can be combined as part of a transaction.
 #[derive(Debug, PartialEq, Eq)]
@@ -263,7 +239,9 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `MAK` = master acknowledge
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
-    fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error>;
+    fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
+        self.transaction(address, &mut [Operation::Read(read)])
+    }
 
     /// Writes bytes to slave with address `address`
     ///
@@ -281,7 +259,9 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `SAK` = slave acknowledge
     /// - `Bi` = ith byte of data
     /// - `SP` = stop condition
-    fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error>;
+    fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error> {
+        self.transaction(address, &mut [Operation::Write(write)])
+    }
 
     /// Writes bytes to slave with address `address` and then reads enough bytes to fill `read` *in a
     /// single transaction*
@@ -305,7 +285,12 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `MAK` = master acknowledge
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
-    fn write_read(&mut self, address: A, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error>;
+    fn write_read(&mut self, address: A, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+        self.transaction(
+            address,
+            &mut [Operation::Write(write), Operation::Read(read)],
+        )
+    }
 
     /// Execute the provided operations on the I2C bus.
     ///

--- a/embedded-hal/src/i2c.rs
+++ b/embedded-hal/src/i2c.rs
@@ -37,23 +37,11 @@
 //!         // ...
 //! #       Ok(())
 //!     }
-//!     fn write_iter<B: IntoIterator<Item = u8>>(&mut self, addr: u8, bytes: B) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
 //!     fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
-//!     fn write_iter_read<B: IntoIterator<Item = u8>>(&mut self, addr: u8, bytes: B, buffer: &mut [u8]) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
 //!     fn transaction<'a>(&mut self, address: u8, operations: &mut [Operation<'a>]) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
-//!     fn transaction_iter<'a, O: IntoIterator<Item = Operation<'a>>>(&mut self, address: u8, operations: O) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
@@ -69,23 +57,11 @@
 //!         // ...
 //! #       Ok(())
 //!     }
-//!     fn write_iter<B: IntoIterator<Item = u8>>(&mut self, addr: u16, bytes: B) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
 //!     fn write_read(&mut self, addr: u16, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
-//!     fn write_iter_read<B: IntoIterator<Item = u8>>(&mut self, addr: u16, bytes: B, buffer: &mut [u8]) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
 //!     fn transaction<'a>(&mut self, address: u16, operations: &mut [Operation<'a>]) -> Result<(), Self::Error> {
-//!         // ...
-//! #       Ok(())
-//!     }
-//!     fn transaction_iter<'a, O: IntoIterator<Item = Operation<'a>>>(&mut self, address: u16, operations: O) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
@@ -307,15 +283,6 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `SP` = stop condition
     fn write(&mut self, address: A, bytes: &[u8]) -> Result<(), Self::Error>;
 
-    /// Writes bytes to slave with address `address`
-    ///
-    /// # I2C Events (contract)
-    ///
-    /// Same as the `write` method
-    fn write_iter<B>(&mut self, address: A, bytes: B) -> Result<(), Self::Error>
-    where
-        B: IntoIterator<Item = u8>;
-
     /// Writes bytes to slave with address `address` and then reads enough bytes to fill `buffer` *in a
     /// single transaction*
     ///
@@ -345,21 +312,6 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
         buffer: &mut [u8],
     ) -> Result<(), Self::Error>;
 
-    /// Writes bytes to slave with address `address` and then reads enough bytes to fill `buffer` *in a
-    /// single transaction*
-    ///
-    /// # I2C Events (contract)
-    ///
-    /// Same as the `write_read` method
-    fn write_iter_read<B>(
-        &mut self,
-        address: A,
-        bytes: B,
-        buffer: &mut [u8],
-    ) -> Result<(), Self::Error>
-    where
-        B: IntoIterator<Item = u8>;
-
     /// Execute the provided operations on the I2C bus.
     ///
     /// Transaction contract:
@@ -378,23 +330,6 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
         address: A,
         operations: &mut [Operation<'a>],
     ) -> Result<(), Self::Error>;
-
-    /// Execute the provided operations on the I2C bus (iterator version).
-    ///
-    /// Transaction contract:
-    /// - Before executing the first operation an ST is sent automatically. This is followed by SAD+R/W as appropriate.
-    /// - Data from adjacent operations of the same type are sent after each other without an SP or SR.
-    /// - Between adjacent operations of a different type an SR and SAD+R/W is sent.
-    /// - After executing the last operation an SP is sent automatically.
-    /// - If the last operation is a `Read` the master does not send an acknowledge for the last byte.
-    ///
-    /// - `ST` = start condition
-    /// - `SAD+R/W` = slave address followed by bit 1 to indicate reading or 0 to indicate writing
-    /// - `SR` = repeated start condition
-    /// - `SP` = stop condition
-    fn transaction_iter<'a, O>(&mut self, address: A, operations: O) -> Result<(), Self::Error>
-    where
-        O: IntoIterator<Item = Operation<'a>>;
 }
 
 impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
@@ -406,13 +341,6 @@ impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
         T::write(self, address, bytes)
     }
 
-    fn write_iter<B>(&mut self, address: A, bytes: B) -> Result<(), Self::Error>
-    where
-        B: IntoIterator<Item = u8>,
-    {
-        T::write_iter(self, address, bytes)
-    }
-
     fn write_read(
         &mut self,
         address: A,
@@ -422,30 +350,11 @@ impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
         T::write_read(self, address, bytes, buffer)
     }
 
-    fn write_iter_read<B>(
-        &mut self,
-        address: A,
-        bytes: B,
-        buffer: &mut [u8],
-    ) -> Result<(), Self::Error>
-    where
-        B: IntoIterator<Item = u8>,
-    {
-        T::write_iter_read(self, address, bytes, buffer)
-    }
-
     fn transaction<'a>(
         &mut self,
         address: A,
         operations: &mut [Operation<'a>],
     ) -> Result<(), Self::Error> {
         T::transaction(self, address, operations)
-    }
-
-    fn transaction_iter<'a, O>(&mut self, address: A, operations: O) -> Result<(), Self::Error>
-    where
-        O: IntoIterator<Item = Operation<'a>>,
-    {
-        T::transaction_iter(self, address, operations)
     }
 }

--- a/embedded-hal/src/i2c.rs
+++ b/embedded-hal/src/i2c.rs
@@ -41,7 +41,7 @@
 //!         // ...
 //! #       Ok(())
 //!     }
-//!     fn transaction<'a>(&mut self, address: u8, operations: &mut [Operation<'a>]) -> Result<(), Self::Error> {
+//!     fn transaction(&mut self, address: u8, operations: &mut [Operation<'_>]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
@@ -61,7 +61,7 @@
 //!         // ...
 //! #       Ok(())
 //!     }
-//!     fn transaction<'a>(&mut self, address: u16, operations: &mut [Operation<'a>]) -> Result<(), Self::Error> {
+//!     fn transaction(&mut self, address: u16, operations: &mut [Operation<'_>]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
@@ -325,10 +325,10 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `SAD+R/W` = slave address followed by bit 1 to indicate reading or 0 to indicate writing
     /// - `SR` = repeated start condition
     /// - `SP` = stop condition
-    fn transaction<'a>(
+    fn transaction(
         &mut self,
         address: A,
-        operations: &mut [Operation<'a>],
+        operations: &mut [Operation<'_>],
     ) -> Result<(), Self::Error>;
 }
 
@@ -350,10 +350,10 @@ impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
         T::write_read(self, address, bytes, buffer)
     }
 
-    fn transaction<'a>(
+    fn transaction(
         &mut self,
         address: A,
-        operations: &mut [Operation<'a>],
+        operations: &mut [Operation<'_>],
     ) -> Result<(), Self::Error> {
         T::transaction(self, address, operations)
     }

--- a/embedded-hal/src/i2c.rs
+++ b/embedded-hal/src/i2c.rs
@@ -29,15 +29,15 @@
 //! # impl ErrorType for I2c0 { type Error = ErrorKind; }
 //! impl I2c<SevenBitAddress> for I2c0
 //! {
-//!     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+//!     fn read(&mut self, addr: u8, read: &mut [u8]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
-//!     fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+//!     fn write(&mut self, addr: u8, write: &[u8]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
-//!     fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
+//!     fn write_read(&mut self, addr: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
@@ -49,15 +49,15 @@
 //!
 //! impl I2c<TenBitAddress> for I2c0
 //! {
-//!     fn read(&mut self, addr: u16, buffer: &mut [u8]) -> Result<(), Self::Error> {
+//!     fn read(&mut self, addr: u16, write: &mut [u8]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
-//!     fn write(&mut self, addr: u16, bytes: &[u8]) -> Result<(), Self::Error> {
+//!     fn write(&mut self, addr: u16, read: &[u8]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
-//!     fn write_read(&mut self, addr: u16, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
+//!     fn write_read(&mut self, addr: u16, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
 //!         // ...
 //! #       Ok(())
 //!     }
@@ -245,7 +245,7 @@ pub enum Operation<'a> {
 
 /// Blocking I2C
 pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
-    /// Reads enough bytes from slave with `address` to fill `buffer`
+    /// Reads enough bytes from slave with `address` to fill `read`
     ///
     /// # I2C Events (contract)
     ///
@@ -263,7 +263,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `MAK` = master acknowledge
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
-    fn read(&mut self, address: A, buffer: &mut [u8]) -> Result<(), Self::Error>;
+    fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error>;
 
     /// Writes bytes to slave with address `address`
     ///
@@ -281,9 +281,9 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `SAK` = slave acknowledge
     /// - `Bi` = ith byte of data
     /// - `SP` = stop condition
-    fn write(&mut self, address: A, bytes: &[u8]) -> Result<(), Self::Error>;
+    fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error>;
 
-    /// Writes bytes to slave with address `address` and then reads enough bytes to fill `buffer` *in a
+    /// Writes bytes to slave with address `address` and then reads enough bytes to fill `read` *in a
     /// single transaction*
     ///
     /// # I2C Events (contract)
@@ -305,12 +305,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `MAK` = master acknowledge
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
-    fn write_read(
-        &mut self,
-        address: A,
-        bytes: &[u8],
-        buffer: &mut [u8],
-    ) -> Result<(), Self::Error>;
+    fn write_read(&mut self, address: A, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error>;
 
     /// Execute the provided operations on the I2C bus.
     ///
@@ -333,21 +328,16 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
 }
 
 impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
-    fn read(&mut self, address: A, buffer: &mut [u8]) -> Result<(), Self::Error> {
-        T::read(self, address, buffer)
+    fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
+        T::read(self, address, read)
     }
 
-    fn write(&mut self, address: A, bytes: &[u8]) -> Result<(), Self::Error> {
-        T::write(self, address, bytes)
+    fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error> {
+        T::write(self, address, write)
     }
 
-    fn write_read(
-        &mut self,
-        address: A,
-        bytes: &[u8],
-        buffer: &mut [u8],
-    ) -> Result<(), Self::Error> {
-        T::write_read(self, address, bytes, buffer)
+    fn write_read(&mut self, address: A, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+        T::write_read(self, address, write, read)
     }
 
     fn transaction(


### PR DESCRIPTION
Some simplifications I think we should do:

- Implement all methods in terms of `transaction`. This way HALs have to implement just that.
- Removed byte-wise-iteration methods: `write_iter` and `write_iter_read`. The reason is that they're quite inefficient, especially with DMA implementations. We've already removed these on other traits, so I think we should do as well here.
- Removed `transaction_iter`. I don't think it's much useful in practice, because the way iterators work all the yielded `Operation`s must have the same lifetime. This means that, even if the user can generate the `Operation`s on the fly, they can't allocate buffers for these on the fly, all buffers must be pre-allocated. So it's not useful for, say, streaming a large transfer by reusing some small buffer repeatedly. See #367 
- Removed useless lifetimes
- Standardized buffer names on `read` and `write`, I think they're clearer.