### PR TITLE
async/serial: add Write.

### DIFF
--- a/embedded-hal-async/src/lib.rs
+++ b/embedded-hal-async/src/lib.rs
@@ -15,4 +15,5 @@
 pub mod delay;
 pub mod digital;
 pub mod i2c;
+pub mod serial;
 pub mod spi;

--- a/embedded-hal-async/src/serial.rs
+++ b/embedded-hal-async/src/serial.rs
@@ -1,0 +1,27 @@
+//! Serial interface
+
+pub use embedded_hal::serial::{Error, ErrorKind, ErrorType};
+
+/// Write half of a serial interface
+pub trait Write<Word: 'static + Copy = u8>: ErrorType {
+    /// Writes a slice, blocking until everything has been written.
+    ///
+    /// An implementation can choose to buffer the write, returning `Ok(())`
+    /// after the complete slice has been written to a buffer, but before all
+    /// words have been sent via the serial interface. To make sure that
+    /// everything has been sent, call [`flush`](Write::flush) after this function returns.
+    async fn write(&mut self, words: &[Word]) -> Result<(), Self::Error>;
+
+    /// Ensures that none of the previously written data is still buffered
+    async fn flush(&mut self) -> Result<(), Self::Error>;
+}
+
+impl<T: Write<Word>, Word: 'static + Copy> Write<Word> for &mut T {
+    async fn write(&mut self, words: &[Word]) -> Result<(), Self::Error> {
+        T::write(self, words).await
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        T::flush(self).await
+    }
+}

--- a/embedded-hal/src/serial.rs
+++ b/embedded-hal/src/serial.rs
@@ -80,9 +80,7 @@ pub trait Write<Word: Copy = u8>: ErrorType {
     /// An implementation can choose to buffer the write, returning `Ok(())`
     /// after the complete slice has been written to a buffer, but before all
     /// words have been sent via the serial interface. To make sure that
-    /// everything has been sent, call [`flush`] after this function returns.
-    ///
-    /// [`flush`]: #tymethod.flush
+    /// everything has been sent, call [`flush`](Write::flush) after this function returns.
     fn write(&mut self, buffer: &[Word]) -> Result<(), Self::Error>;
 
     /// Block until the serial interface has sent all buffered words


### PR DESCRIPTION
Extracted out of #349 

This is just `Write`, mirroring the blocking version. so it should hopefully be uncontroversial.