### PR TITLE
Release e-h v1.0.0-alpha.10, e-h-async v0.2.0-alpha.1, e-h-bus v0.1.0…

### DIFF
--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.0-alpha.1] - 2023-04-04
+
 ### Added
 - Added a `serial::Write` trait.
 
 ### Changed
+- Updated `embedded-hal` to version `1.0.0-alpha.10`.
 - delay: make infallible.
 - i2c: remove `_iter()` methods.
 - i2c: add default implementations for all methods based on `transaction()`.
@@ -46,7 +49,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 First release to crates.io
 
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.2.0-alpha.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.2.0-alpha.1...HEAD
+[v0.2.0-alpha.1]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.2.0-alpha.0...embedded-hal-async-v0.2.0-alpha.1
 [v0.2.0-alpha.0]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.1.0-alpha.3...embedded-hal-async-v0.2.0-alpha.0
 [v0.1.0-alpha.3]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.1.0-alpha.2...embedded-hal-async-v0.1.0-alpha.3
 [v0.1.0-alpha.2]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.1.0-alpha.1...embedded-hal-async-v0.1.0-alpha.2

--- a/embedded-hal-async/Cargo.toml
+++ b/embedded-hal-async/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal-async"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "0.2.0-alpha.0"
+version = "0.2.0-alpha.1"
 rust-version = "1.65.0"
 
 [dependencies]
-embedded-hal = { version = "=1.0.0-alpha.9", path = "../embedded-hal" }
+embedded-hal = { version = "=1.0.0-alpha.10", path = "../embedded-hal" }

--- a/embedded-hal-bus/CHANGELOG.md
+++ b/embedded-hal-bus/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.1.0-alpha.2] - 2023-04-04
+
+### Changed
+- Updated `embedded-hal` to version `1.0.0-alpha.10`.
+
 ### Added
 - i2c: add bus sharing implementations.
 - spi: add bus sharing implementations.
@@ -20,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 First release to crates.io
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-alpha.1...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-alpha.2...HEAD
+[v0.1.0-alpha.2]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-alpha.1...embedded-hal-bus-v0.1.0-alpha.2
 [v0.1.0-alpha.1]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-alpha.0...embedded-hal-bus-v0.1.0-alpha.1
 [v0.1.0-alpha.0]: https://github.com/rust-embedded/embedded-hal/tree/embedded-hal-bus-v0.1.0-alpha.0

--- a/embedded-hal-bus/Cargo.toml
+++ b/embedded-hal-bus/Cargo.toml
@@ -11,11 +11,11 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal-bus"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 
 [features]
 std = []
 
 [dependencies]
-embedded-hal = { version = "=1.0.0-alpha.9", path = "../embedded-hal" }
+embedded-hal = { version = "=1.0.0-alpha.10", path = "../embedded-hal" }
 critical-section = { version = "1.0" }

--- a/embedded-hal-bus/README.md
+++ b/embedded-hal-bus/README.md
@@ -15,7 +15,7 @@ This project is developed and maintained by the [HAL team](https://github.com/ru
 
 To support bus sharing, `embedded-hal` provides the `SpiBus` and `SpiDevice` traits. `SpiBus` represents an entire bus,
 while `SpiDevice` represents a device on that bus. For further details on these traits, please consult the
-[`embedded-hal` documentation](https://docs.rs/embedded-hal/1.0.0-alpha.9/embedded_hal/spi/index.html).
+[`embedded-hal` documentation](https://docs.rs/embedded-hal/1.0.0-alpha.10/embedded_hal/spi/index.html).
 
 `embedded-hal` trait implementations for microcontrollers should implement the `SpiBus` trait.
 However, device drivers should use the `SpiDevice` traits, _not the `SpiBus` traits_ if at all possible

--- a/embedded-hal-nb/CHANGELOG.md
+++ b/embedded-hal-nb/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ...
 
+## [v1.0.0-alpha.2] - 2023-04-04
+
+### Changed
+- Updated `embedded-hal` to version `1.0.0-alpha.10`.
+
 ## [v1.0.0-alpha.1] - 2022-09-28
 
 ### Changed
@@ -18,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 First release to crates.io
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-nb-v1.0.0-alpha.1...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-nb-v1.0.0-alpha.2...HEAD
+[v1.0.0-alpha.2]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-nb-v1.0.0-alpha.1...embedded-hal-nb-v1.0.0-alpha.2which
 [v1.0.0-alpha.1]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-nb-v1.0.0-alpha.0...embedded-hal-nb-v1.0.0-alpha.1
 [v1.0.0-alpha.0]: https://github.com/rust-embedded/embedded-hal/tree/embedded-hal-nb-v1.0.0-alpha.0

--- a/embedded-hal-nb/Cargo.toml
+++ b/embedded-hal-nb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-hal-nb"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 edition = "2021"
 
 categories = ["embedded", "hardware-support", "no-std"]
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
 
 [dependencies]
-embedded-hal = { version = "=1.0.0-alpha.9", path = "../embedded-hal" }
+embedded-hal = { version = "=1.0.0-alpha.10", path = "../embedded-hal" }
 nb = "1"
 
 [dev-dependencies]

--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v1.0.0-alpha.10] - 2023-04-04
+
+*** This is (also) an alpha release with breaking changes (sorry) ***
+
 ### Added
 - Added `pwm::SetDutyCycle` trait.
 

--- a/embedded-hal/Cargo.toml
+++ b/embedded-hal/Cargo.toml
@@ -2,7 +2,7 @@
 authors = [
   "The Embedded HAL Team <embedded-hal@teams.rust-embedded.org>",
   "Jorge Aparicio <jorge@japaric.io>",
-  "Jonathan 'theJPster' Pallant <github@thejpster.org.uk>"
+  "Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
 ]
 categories = ["asynchronous", "embedded", "hardware-support", "no-std"]
 description = " A Hardware Abstraction Layer (HAL) for embedded systems "
@@ -13,4 +13,4 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "1.0.0-alpha.9"
+version = "1.0.0-alpha.10"


### PR DESCRIPTION
…-alpha.2, e-h-nb v1.0.0-alpha.2.

lots of crates, whew :sweat_smile: 