### PR TITLE
spi: add Operation::DelayUs(u32).

### DIFF
--- a/embedded-hal-bus/src/spi/mod.rs
+++ b/embedded-hal-bus/src/spi/mod.rs
@@ -35,3 +35,12 @@ where
         }
     }
 }
+
+/// Dummy `DelayUs` implementation that panics on use.
+pub struct NoDelay;
+
+impl embedded_hal::delay::DelayUs for NoDelay {
+    fn delay_us(&mut self, _us: u32) {
+        panic!("You've tried to execute a SPI transaction containing a `Operation::Delay` in a `SpiDevice` created with `new_no_delay()`. Create it with `new()` instead, passing a `DelayUs` implementation.")
+    }
+}

--- a/embedded-hal-bus/src/spi/mutex.rs
+++ b/embedded-hal-bus/src/spi/mutex.rs
@@ -1,3 +1,4 @@
+use embedded_hal::delay::DelayUs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 use std::sync::Mutex;
@@ -12,19 +13,36 @@ use super::DeviceError;
 /// Sharing is implemented with a `std` [`Mutex`](std::sync::Mutex). It allows a single bus across multiple threads,
 /// with finer-grained locking than [`CriticalSectionDevice`](super::CriticalSectionDevice). The downside is
 /// it is only available in `std` targets.
-pub struct MutexDevice<'a, BUS, CS> {
+pub struct MutexDevice<'a, BUS, CS, D> {
     bus: &'a Mutex<BUS>,
     cs: CS,
+    delay: D,
 }
 
-impl<'a, BUS, CS> MutexDevice<'a, BUS, CS> {
+impl<'a, BUS, CS, D> MutexDevice<'a, BUS, CS, D> {
     /// Create a new ExclusiveDevice
-    pub fn new(bus: &'a Mutex<BUS>, cs: CS) -> Self {
-        Self { bus, cs }
+    pub fn new(bus: &'a Mutex<BUS>, cs: CS, delay: D) -> Self {
+        Self { bus, cs, delay }
     }
 }
 
-impl<'a, BUS, CS> ErrorType for MutexDevice<'a, BUS, CS>
+impl<'a, BUS, CS> MutexDevice<'a, BUS, CS, super::NoDelay> {
+    /// Create a new MutexDevice without support for in-transaction delays.
+    ///
+    /// # Panics
+    ///
+    /// The returned device will panic if you try to execute a transaction
+    /// that contains any operations of type `Operation::DelayUs`.
+    pub fn new_no_delay(bus: &'a Mutex<BUS>, cs: CS) -> Self {
+        Self {
+            bus,
+            cs,
+            delay: super::NoDelay,
+        }
+    }
+}
+
+impl<'a, BUS, CS, D> ErrorType for MutexDevice<'a, BUS, CS, D>
 where
     BUS: ErrorType,
     CS: OutputPin,
@@ -32,10 +50,11 @@ where
     type Error = DeviceError<BUS::Error, CS::Error>;
 }
 
-impl<'a, Word: Copy + 'static, BUS, CS> SpiDevice<Word> for MutexDevice<'a, BUS, CS>
+impl<'a, Word: Copy + 'static, BUS, CS, D> SpiDevice<Word> for MutexDevice<'a, BUS, CS, D>
 where
     BUS: SpiBus<Word>,
     CS: OutputPin,
+    D: DelayUs,
 {
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {
         let bus = &mut *self.bus.lock().unwrap();
@@ -47,6 +66,11 @@ where
             Operation::Write(buf) => bus.write(buf),
             Operation::Transfer(read, write) => bus.transfer(read, write),
             Operation::TransferInPlace(buf) => bus.transfer_in_place(buf),
+            Operation::DelayUs(us) => {
+                bus.flush()?;
+                self.delay.delay_us(*us);
+                Ok(())
+            }
         });
 
         // On failure, it's important to still flush and deassert CS.

--- a/embedded-hal-bus/src/spi/refcell.rs
+++ b/embedded-hal-bus/src/spi/refcell.rs
@@ -1,4 +1,5 @@
 use core::cell::RefCell;
+use embedded_hal::delay::DelayUs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 
@@ -12,19 +13,36 @@ use super::DeviceError;
 /// Sharing is implemented with a `RefCell`. This means it has low overhead, but `RefCellDevice` instances are not `Send`,
 /// so it only allows sharing within a single thread (interrupt priority level). If you need to share a bus across several
 /// threads, use [`CriticalSectionDevice`](super::CriticalSectionDevice) instead.
-pub struct RefCellDevice<'a, BUS, CS> {
+pub struct RefCellDevice<'a, BUS, CS, D> {
     bus: &'a RefCell<BUS>,
     cs: CS,
+    delay: D,
 }
 
-impl<'a, BUS, CS> RefCellDevice<'a, BUS, CS> {
+impl<'a, BUS, CS, D> RefCellDevice<'a, BUS, CS, D> {
     /// Create a new ExclusiveDevice
-    pub fn new(bus: &'a RefCell<BUS>, cs: CS) -> Self {
-        Self { bus, cs }
+    pub fn new(bus: &'a RefCell<BUS>, cs: CS, delay: D) -> Self {
+        Self { bus, cs, delay }
     }
 }
 
-impl<'a, BUS, CS> ErrorType for RefCellDevice<'a, BUS, CS>
+impl<'a, BUS, CS> RefCellDevice<'a, BUS, CS, super::NoDelay> {
+    /// Create a new RefCellDevice without support for in-transaction delays.
+    ///
+    /// # Panics
+    ///
+    /// The returned device will panic if you try to execute a transaction
+    /// that contains any operations of type `Operation::DelayUs`.
+    pub fn new_no_delay(bus: &'a RefCell<BUS>, cs: CS) -> Self {
+        Self {
+            bus,
+            cs,
+            delay: super::NoDelay,
+        }
+    }
+}
+
+impl<'a, BUS, CS, D> ErrorType for RefCellDevice<'a, BUS, CS, D>
 where
     BUS: ErrorType,
     CS: OutputPin,
@@ -32,10 +50,11 @@ where
     type Error = DeviceError<BUS::Error, CS::Error>;
 }
 
-impl<'a, Word: Copy + 'static, BUS, CS> SpiDevice<Word> for RefCellDevice<'a, BUS, CS>
+impl<'a, Word: Copy + 'static, BUS, CS, D> SpiDevice<Word> for RefCellDevice<'a, BUS, CS, D>
 where
     BUS: SpiBus<Word>,
     CS: OutputPin,
+    D: DelayUs,
 {
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {
         let bus = &mut *self.bus.borrow_mut();
@@ -47,6 +66,11 @@ where
             Operation::Write(buf) => bus.write(buf),
             Operation::Transfer(read, write) => bus.transfer(read, write),
             Operation::TransferInPlace(buf) => bus.transfer_in_place(buf),
+            Operation::DelayUs(us) => {
+                bus.flush()?;
+                self.delay.delay_us(*us);
+                Ok(())
+            }
         });
 
         // On failure, it's important to still flush and deassert CS.

--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- spi: added `Operation::DelayUs(u32)`.
+
 ### Removed
 - spi: removed read-only and write-only traits.
 

--- a/embedded-hal/src/spi.rs
+++ b/embedded-hal/src/spi.rs
@@ -313,6 +313,8 @@ pub enum Operation<'a, Word: 'static> {
     ///
     /// Equivalent to [`SpiBus::transfer_in_place`].
     TransferInPlace(&'a mut [Word]),
+    /// Delay for at least the specified number of microseconds
+    DelayUs(u32),
 }
 
 /// SPI device trait


### PR DESCRIPTION
depends on #461

There are SPI devices out there that need delays between transfers within a transaction. *Not* dummy bytes, SCK must be idle during the delay. And it must be a single transaction, CS must not be deasserted.

This is not doable with the new operation-list API (it was doable with the previous closure API).

Examples:

- ADS1255/56 needs a 7 micro second delay between the command to read a register and reading the corresponding data over SPI. [datasheet](https://www.ti.com/lit/ds/symlink/ads1256.pdf?ts=1683244329972&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252Fes-mx%252FADS1256) page 34. [matrix discussion](https://matrix.to/#/!BHcierreUuwCMxVqOf:matrix.org/$b97m_oLuXJs7vzzmV395FEyq4gUr1pO1Via9cshnFQ0?via=matrix.org&via=psion.agg.io&via=tchncs.de).
-  CAM312 Central Tracking Unit [datasheet](https://www.cambridgeic.com/resources/downloads/39-033-0068-cam312/file), Section 9.3. [matrix discussion](https://matrix.to/#/!BHcierreUuwCMxVqOf:matrix.org/$Cv2muTA878kdwufyM3ZovTFOw65g5dmk1qgiH-1wcJQ?via=matrix.org&via=psion.agg.io&via=tchncs.de)

To support these, this adds a new `Operation::DelayUs(u32)`.

Linux spidev can implement this fine, it [supports](https://github.com/torvalds/linux/blob/master/include/uapi/linux/spi/spidev.h#L42) delaying after each transfer.

The downside is that `SpiDevice` impls now need a time source. [Discussed a bit](https://matrix.to/#/!BHcierreUuwCMxVqOf:matrix.org/$DQFvuFyeU2T4ikBj_uB16wYoLFDvk5wes7gZrGKUDmU?via=matrix.org&via=psion.agg.io&via=tchncs.de) in yesterday's WG meeting.

I don't think separating the traits by capability is worth it, we end up with the same problem as with the read-only/write-only traits (#461)