### PR TITLE
Add `+ ?Sized` to all blanket impls.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 # CI removes lines containing 'nightly-only' when not building with nightly.
 members = [

--- a/embedded-hal-async/src/delay.rs
+++ b/embedded-hal-async/src/delay.rs
@@ -13,7 +13,7 @@ pub trait DelayUs {
 
 impl<T> DelayUs for &mut T
 where
-    T: DelayUs,
+    T: DelayUs + ?Sized,
 {
     async fn delay_us(&mut self, us: u32) {
         T::delay_us(self, us).await

--- a/embedded-hal-async/src/digital.rs
+++ b/embedded-hal-async/src/digital.rs
@@ -48,7 +48,7 @@ pub trait Wait: embedded_hal::digital::ErrorType {
     async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error>;
 }
 
-impl<T: Wait> Wait for &mut T {
+impl<T: Wait + ?Sized> Wait for &mut T {
     async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
         T::wait_for_high(self).await
     }

--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -122,7 +122,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     ) -> Result<(), Self::Error>;
 }
 
-impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
+impl<A: AddressMode, T: I2c<A> + ?Sized> I2c<A> for &mut T {
     async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
         T::read(self, address, read).await
     }

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -76,7 +76,7 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     }
 }
 
-impl<Word: Copy + 'static, T: SpiDevice<Word>> SpiDevice<Word> for &mut T {
+impl<Word: Copy + 'static, T: SpiDevice<Word> + ?Sized> SpiDevice<Word> for &mut T {
     async fn transaction(
         &mut self,
         operations: &mut [Operation<'_, Word>],
@@ -149,7 +149,7 @@ pub trait SpiBus<Word: 'static + Copy = u8>: ErrorType {
     async fn flush(&mut self) -> Result<(), Self::Error>;
 }
 
-impl<T: SpiBus<Word>, Word: 'static + Copy> SpiBus<Word> for &mut T {
+impl<T: SpiBus<Word> + ?Sized, Word: 'static + Copy> SpiBus<Word> for &mut T {
     async fn read(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
         T::read(self, words).await
     }

--- a/embedded-hal-nb/src/serial.rs
+++ b/embedded-hal-nb/src/serial.rs
@@ -69,7 +69,7 @@ pub trait ErrorType {
     type Error: Error;
 }
 
-impl<T: ErrorType> ErrorType for &mut T {
+impl<T: ErrorType + ?Sized> ErrorType for &mut T {
     type Error = T::Error;
 }
 
@@ -82,7 +82,7 @@ pub trait Read<Word: Copy = u8>: ErrorType {
     fn read(&mut self) -> nb::Result<Word, Self::Error>;
 }
 
-impl<T: Read<Word>, Word: Copy> Read<Word> for &mut T {
+impl<T: Read<Word> + ?Sized, Word: Copy> Read<Word> for &mut T {
     fn read(&mut self) -> nb::Result<Word, Self::Error> {
         T::read(self)
     }
@@ -97,7 +97,7 @@ pub trait Write<Word: Copy = u8>: ErrorType {
     fn flush(&mut self) -> nb::Result<(), Self::Error>;
 }
 
-impl<T: Write<Word>, Word: Copy> Write<Word> for &mut T {
+impl<T: Write<Word> + ?Sized, Word: Copy> Write<Word> for &mut T {
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error> {
         T::write(self, word)
     }

--- a/embedded-hal-nb/src/spi.rs
+++ b/embedded-hal-nb/src/spi.rs
@@ -31,7 +31,7 @@ pub trait FullDuplex<Word: Copy = u8>: ErrorType {
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error>;
 }
 
-impl<T: FullDuplex<Word>, Word: Copy> FullDuplex<Word> for &mut T {
+impl<T: FullDuplex<Word> + ?Sized, Word: Copy> FullDuplex<Word> for &mut T {
     fn read(&mut self) -> nb::Result<Word, Self::Error> {
         T::read(self)
     }

--- a/embedded-hal/src/delay.rs
+++ b/embedded-hal/src/delay.rs
@@ -18,7 +18,7 @@ pub trait DelayUs {
 
 impl<T> DelayUs for &mut T
 where
-    T: DelayUs,
+    T: DelayUs + ?Sized,
 {
     fn delay_us(&mut self, us: u32) {
         T::delay_us(self, us)

--- a/embedded-hal/src/digital.rs
+++ b/embedded-hal/src/digital.rs
@@ -55,11 +55,11 @@ pub trait ErrorType {
     type Error: Error;
 }
 
-impl<T: ErrorType> ErrorType for &T {
+impl<T: ErrorType + ?Sized> ErrorType for &T {
     type Error = T::Error;
 }
 
-impl<T: ErrorType> ErrorType for &mut T {
+impl<T: ErrorType + ?Sized> ErrorType for &mut T {
     type Error = T::Error;
 }
 
@@ -139,7 +139,7 @@ pub trait OutputPin: ErrorType {
     }
 }
 
-impl<T: OutputPin> OutputPin for &mut T {
+impl<T: OutputPin + ?Sized> OutputPin for &mut T {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         T::set_low(self)
     }
@@ -166,7 +166,7 @@ pub trait StatefulOutputPin: OutputPin {
     fn is_set_low(&self) -> Result<bool, Self::Error>;
 }
 
-impl<T: StatefulOutputPin> StatefulOutputPin for &mut T {
+impl<T: StatefulOutputPin + ?Sized> StatefulOutputPin for &mut T {
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         T::is_set_high(self)
     }
@@ -182,7 +182,7 @@ pub trait ToggleableOutputPin: ErrorType {
     fn toggle(&mut self) -> Result<(), Self::Error>;
 }
 
-impl<T: ToggleableOutputPin> ToggleableOutputPin for &mut T {
+impl<T: ToggleableOutputPin + ?Sized> ToggleableOutputPin for &mut T {
     fn toggle(&mut self) -> Result<(), Self::Error> {
         T::toggle(self)
     }
@@ -197,7 +197,7 @@ pub trait InputPin: ErrorType {
     fn is_low(&self) -> Result<bool, Self::Error>;
 }
 
-impl<T: InputPin> InputPin for &T {
+impl<T: InputPin + ?Sized> InputPin for &T {
     fn is_high(&self) -> Result<bool, Self::Error> {
         T::is_high(self)
     }

--- a/embedded-hal/src/i2c.rs
+++ b/embedded-hal/src/i2c.rs
@@ -249,7 +249,7 @@ pub trait ErrorType {
     type Error: Error;
 }
 
-impl<T: ErrorType> ErrorType for &mut T {
+impl<T: ErrorType + ?Sized> ErrorType for &mut T {
     type Error = T::Error;
 }
 
@@ -372,7 +372,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     ) -> Result<(), Self::Error>;
 }
 
-impl<A: AddressMode, T: I2c<A>> I2c<A> for &mut T {
+impl<A: AddressMode, T: I2c<A> + ?Sized> I2c<A> for &mut T {
     fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
         T::read(self, address, read)
     }

--- a/embedded-hal/src/pwm.rs
+++ b/embedded-hal/src/pwm.rs
@@ -53,7 +53,7 @@ pub trait ErrorType {
     type Error: Error;
 }
 
-impl<T: ErrorType> ErrorType for &mut T {
+impl<T: ErrorType + ?Sized> ErrorType for &mut T {
     type Error = T::Error;
 }
 
@@ -101,7 +101,7 @@ pub trait SetDutyCycle: ErrorType {
     }
 }
 
-impl<T: SetDutyCycle> SetDutyCycle for &mut T {
+impl<T: SetDutyCycle + ?Sized> SetDutyCycle for &mut T {
     fn get_max_duty_cycle(&self) -> u16 {
         T::get_max_duty_cycle(self)
     }

--- a/embedded-hal/src/spi.rs
+++ b/embedded-hal/src/spi.rs
@@ -288,7 +288,7 @@ pub trait ErrorType {
     type Error: Error;
 }
 
-impl<T: ErrorType> ErrorType for &mut T {
+impl<T: ErrorType + ?Sized> ErrorType for &mut T {
     type Error = T::Error;
 }
 
@@ -378,7 +378,7 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     }
 }
 
-impl<Word: Copy + 'static, T: SpiDevice<Word>> SpiDevice<Word> for &mut T {
+impl<Word: Copy + 'static, T: SpiDevice<Word> + ?Sized> SpiDevice<Word> for &mut T {
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {
         T::transaction(self, operations)
     }
@@ -448,7 +448,7 @@ pub trait SpiBus<Word: Copy + 'static = u8>: ErrorType {
     fn flush(&mut self) -> Result<(), Self::Error>;
 }
 
-impl<T: SpiBus<Word>, Word: Copy + 'static> SpiBus<Word> for &mut T {
+impl<T: SpiBus<Word> + ?Sized, Word: Copy + 'static> SpiBus<Word> for &mut T {
     fn read(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
         T::read(self, words)
     }


### PR DESCRIPTION
It doesn't make much of a difference in practice because unsized types are rare, but it's best practice to do so, so why not.