### PR TITLE
Add bus access methods to `ExclusiveDevice`

### DIFF
--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- spi: added `ExclusiveDevice::{bus, bus_mut}`.
+
 ## [v0.2.0-alpha.2] - 2023-07-04
 
 ### Added

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -208,6 +208,16 @@ impl<BUS, CS, D> ExclusiveDevice<BUS, CS, D> {
     pub fn new(bus: BUS, cs: CS, delay: D) -> Self {
         Self { bus, cs, delay }
     }
+
+    /// Returns a reference to the underlying bus object.
+    pub fn bus(&self) -> &BUS {
+        &self.bus
+    }
+
+    /// Returns a mutable reference to the underlying bus object.
+    pub fn bus_mut(&mut self) -> &mut BUS {
+        &mut self.bus
+    }
 }
 
 impl<BUS, CS, D> ErrorType for ExclusiveDevice<BUS, CS, D>


### PR DESCRIPTION
Closes #467

I've chosen `bus` and `bus_mut` instead of `inner{_mut}` because ExclusiveDevice also wraps CS and Delay, so "inner" isn't very descriptive here. I've also opted to not implement `into_inner` for the same reason, and because a destructuring conversion would need to return both the bus, the chip select and the delay, too. So in summary, this PR is the minimal, hopefully non-controversial subset of additions.