### PR TITLE
io: add defmt support, release v0.5

### DIFF
--- a/embedded-io-adapters/CHANGELOG.md
+++ b/embedded-io-adapters/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.5.0 - 2023-08-06
+
+- First release

--- a/embedded-io-adapters/Cargo.toml
+++ b/embedded-io-adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-io-adapters"
-version = "0.1.0"
+version = "0.5.0"
 edition = "2021"
 description = "Adapters between the `embedded-io` traits and other I/O traits"
 repository = "https://github.com/rust-embedded/embedded-hal"

--- a/embedded-io-adapters/src/std.rs
+++ b/embedded-io-adapters/src/std.rs
@@ -66,6 +66,7 @@ impl<T: std::io::Seek + ?Sized> embedded_io::Seek for FromStd<T> {
 }
 
 /// Adapter to `std::io` traits.
+#[derive(Clone)]
 pub struct ToStd<T: ?Sized> {
     inner: T,
 }

--- a/embedded-io-async/CHANGELOG.md
+++ b/embedded-io-async/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.5.0 - 2023-08-06
+
+- First release

--- a/embedded-io-async/Cargo.toml
+++ b/embedded-io-async/Cargo.toml
@@ -14,9 +14,11 @@ categories = [
 [features]
 std = ["alloc", "embedded-io/std"]
 alloc = ["embedded-io/alloc"]
+defmt-03 = ["dep:defmt-03", "embedded-io/defmt-03"]
 
 [dependencies]
 embedded-io = { version = "0.5", path = "../embedded-io" }
+defmt-03 = { package = "defmt", version = "0.3", optional = true }
 
 [package.metadata.docs.rs]
 features = ["std"]

--- a/embedded-io/CHANGELOG.md
+++ b/embedded-io/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.5.0 - 2023-08-06
 
 - Add `ReadReady`, `WriteReady` traits. They allow peeking whether the I/O handle is ready to read/write, so they allow using the traits in a non-blocking way.
 - Add variants to `ErrorKind` mirroring `std::io::ErrorKind`.
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved `embedded_io::blocking` to the crate root.
 - Split async traits to the `embedded-io-async` crate.
 - Split trait adapters to the `embedded-io-adapters` crate.
-- Add `std::io` impls for `ReadExactError` & `WriteAllError`.
+- Add `std::error` impls for `ReadExactError` & `WriteAllError`.
 - Rename trait `Io` to `ErrorKind`, for consistency with `embedded-hal`.
 
 ## 0.4.0 - 2022-11-25

--- a/embedded-io/Cargo.toml
+++ b/embedded-io/Cargo.toml
@@ -15,6 +15,9 @@ categories = [
 std = ["alloc"]
 alloc = []
 
+[dependencies]
+defmt-03 = { package = "defmt", version = "0.3", optional = true }
+
 [package.metadata.docs.rs]
 features = ["std"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -5,6 +5,10 @@
 
 use core::fmt;
 
+// needed to prevent defmt macros from breaking, since they emit code that does `defmt::blahblah`.
+#[cfg(feature = "defmt-03")]
+use defmt_03 as defmt;
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
@@ -14,6 +18,7 @@ mod impls;
 ///
 /// This is the `embedded-io` equivalent of [`std::io::SeekFrom`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum SeekFrom {
     /// Sets the offset to the provided number of bytes.
     Start(u64),
@@ -47,8 +52,6 @@ impl From<std::io::SeekFrom> for SeekFrom {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[non_exhaustive]
 /// Possible kinds of errors.
 ///
 /// This list is intended to grow over time and it is not recommended to
@@ -59,6 +62,9 @@ impl From<std::io::SeekFrom> for SeekFrom {
 ///
 /// - `WouldBlock` is removed, since `embedded-io` traits are always blocking. See the [crate-level documentation](crate) for details.
 /// - `WriteZero` is removed, since it is a separate variant in [`WriteAllError`] and [`WriteFmtError`].
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Unspecified error kind.
     Other,
@@ -214,6 +220,7 @@ impl<T: ?Sized + ErrorType> ErrorType for &mut T {
 
 /// Error returned by [`Read::read_exact`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum ReadExactError<E> {
     /// An EOF error was encountered before reading the exact amount of requested bytes.
     UnexpectedEof,
@@ -266,6 +273,7 @@ impl<E: fmt::Debug> std::error::Error for ReadExactError<E> {}
 
 /// Error returned by [`Write::write_fmt`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum WriteFmtError<E> {
     /// [`Write::write`] wrote zero bytes
     WriteZero,
@@ -293,6 +301,7 @@ impl<E: fmt::Debug> std::error::Error for WriteFmtError<E> {}
 
 /// Error returned by [`Write::write_all`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum WriteAllError<E> {
     /// [`Write::write`] wrote zero bytes
     WriteZero,


### PR DESCRIPTION
following discussions in #450, the Cargo feature is named `defmt-03` instead of `defmt`. This leaves the door open to add support for newer versions of defmt in the future without breaking changes, naming the features `defmt-04` or `defmt-1`, like this:

```toml
[dependencies]
defmt-03 = { package = "defmt", version = "0.3", optional = true }
defmt-04 = { package = "defmt", version = "0.4", optional = true }
```

```rust
// needed to prevent defmt macros from breaking, since they emit code that does `defmt::blahblah`.
#[cfg(feature = "defmt-03")]
use defmt_03 as defmt;
#[cfg(feature = "defmt-04")]
use defmt_04 as defmt;

[cfg_attr(any(feature = "defmt-03", feature = "defmt-04"), derive(defmt::Format))]
pub enum Blah { .. }
```

One downside is this breaks if you enable both `defmt-03` and `defmt-04`. This is annoying, because in theory it should be possible to impl both the 0.3 and 0.4 `Format` on the same struct. However in practice it's unlikely that a user wants this since `defmt` doesn't allow mixing major versions in the same binary anyway.

