### PR TITLE
Fix doc links for adapters, add features

### DIFF
--- a/embedded-io-adapters/Cargo.toml
+++ b/embedded-io-adapters/Cargo.toml
@@ -24,5 +24,5 @@ futures = { version = "0.3.21", features = ["std"], default-features = false, op
 tokio = { version = "1", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
-features = ["std"]
+features = ["std", "tokio-1", "futures-03"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/embedded-io-adapters/README.md
+++ b/embedded-io-adapters/README.md
@@ -1,6 +1,6 @@
-[![crates.io](https://img.shields.io/crates/d/embedded-io.svg)](https://crates.io/crates/embedded-io)
-[![crates.io](https://img.shields.io/crates/v/embedded-io.svg)](https://crates.io/crates/embedded-io)
-[![Documentation](https://docs.rs/embedded-io/badge.svg)](https://docs.rs/embedded-io)
+[![crates.io](https://img.shields.io/crates/d/embedded-io-adapters.svg)](https://crates.io/crates/embedded-io-adapters)
+[![crates.io](https://img.shields.io/crates/v/embedded-io-adapters.svg)](https://crates.io/crates/embedded-io-adapters)
+[![Documentation](https://docs.rs/embedded-io-adapters/badge.svg)](https://docs.rs/embedded-io-adapters)
 
 # `embedded-io-adapters`
 


### PR DESCRIPTION
The doc links in the README needed updating
Include tokio and futures features in docs