### PR TITLE
Release embedded-hal{,-async,-nb} v1.0.0-rc.1, embedded-hal-bus v0.1.0-rc.1

### DIFF
--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Added
-- spi: added `ExclusiveDevice::{bus, bus_mut}`.
+## [v1.0.0-rc.1] - 2023-08-15
+
+- Updated `embedded-hal` to version `1.0.0-rc.1`.
+- Add optional `defmt` 0.3 support.
+- Remove serial traits, the replacement is the `embedded-io` crate.
+- Added `+ ?Sized` to all blanket impls.
+- Moved `ExclusiveDevice` to `embedded-hal-bus`.
 
 ## [v0.2.0-alpha.2] - 2023-07-04
 
@@ -64,7 +69,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 First release to crates.io
 
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.2.0-alpha.2...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v1.0.0-rc.1...HEAD
+[v1.0.0-rc.1]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.2.0-alpha.2...embedded-hal-async-v1.0.0-rc.1
 [v0.2.0-alpha.2]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.2.0-alpha.1...embedded-hal-async-v0.2.0-alpha.2
 [v0.2.0-alpha.1]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.2.0-alpha.0...embedded-hal-async-v0.2.0-alpha.1
 [v0.2.0-alpha.0]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-async-v0.1.0-alpha.3...embedded-hal-async-v0.2.0-alpha.0

--- a/embedded-hal-async/Cargo.toml
+++ b/embedded-hal-async/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal-async"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "0.2.0-alpha.2"
+version = "1.0.0-rc.1"
 rust-version = "1.65.0"
 
 [features]
 defmt-03 = ["dep:defmt-03", "embedded-hal/defmt-03"]
 
 [dependencies]
-embedded-hal = { version = "=1.0.0-alpha.11", path = "../embedded-hal" }
+embedded-hal = { version = "=1.0.0-rc.1", path = "../embedded-hal" }
 defmt-03 = { package = "defmt", version = "0.3", optional = true }

--- a/embedded-hal-async/README.md
+++ b/embedded-hal-async/README.md
@@ -17,13 +17,21 @@ A serial port is essentially a byte-oriented stream, and that's what `embedded-i
 with all byte streams has some advantages. For example, it allows generic code providing a command-line interface
 or a console to operate either on hardware serial ports or on virtual ones like Telnet or USB CDC-ACM.
 
+## Optional Cargo features
+
+- **`defmt-03`**: Derive `defmt::Format` from `defmt` 0.3 for enums and structs.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate requires Rust nightly newer than `nightly-2022-11-22`, due to requiring support for
-`async fn` in traits (AFIT), which is not stable yet. 
+`async fn` in traits (AFIT), which is not stable yet.
 
 Keep in mind Rust nightlies can make backwards-incompatible changes to unstable features
-at any time.
+at any time. If this happens, we might do changes that increase the minimum required nightly
+version in any patch release.
+
+When AFIT becomes stable, MSRV will be bumped to the Rust version that stabilizes it, after which
+point the [standard MSRV bump policy](../docs/msrv.md) will apply.
 
 ## License
 

--- a/embedded-hal-bus/CHANGELOG.md
+++ b/embedded-hal-bus/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.1.0-rc.1] - 2023-08-15
+
+- Updated `embedded-hal`, `embedded-hal-async` to version `1.0.0-rc.1`.
+- The Minimum Supported Rust Version (MSRV) is now 1.60.0
+- Added `embedded-hal-async` support to SPI `ExclusiveDevice`.
+- Added methods to access the inner bus to SPI `ExclusiveDevice`.
+- Add optional `defmt` 0.3 support.
+
 ## [v0.1.0-alpha.3] - 2023-07-04
 
 ### Changed
@@ -31,7 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 First release to crates.io
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-alpha.3...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-rc.1...HEAD
+[v0.1.0-rc.1]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-alpha.3...embedded-hal-bus-v0.1.0-rc.1
 [v0.1.0-alpha.3]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-alpha.2...embedded-hal-bus-v0.1.0-alpha.3
 [v0.1.0-alpha.2]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-alpha.1...embedded-hal-bus-v0.1.0-alpha.2
 [v0.1.0-alpha.1]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-alpha.0...embedded-hal-bus-v0.1.0-alpha.1

--- a/embedded-hal-bus/Cargo.toml
+++ b/embedded-hal-bus/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal-bus"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "0.1.0-alpha.3"
+version = "0.1.0-rc.1"
 
 [features]
 std = []
@@ -19,8 +19,8 @@ async = ["dep:embedded-hal-async"]
 defmt-03 = ["dep:defmt-03", "embedded-hal/defmt-03", "embedded-hal-async?/defmt-03"]
 
 [dependencies]
-embedded-hal = { version = "=1.0.0-alpha.11", path = "../embedded-hal" }
-embedded-hal-async = { version = "=0.2.0-alpha.2", path = "../embedded-hal-async", optional = true }
+embedded-hal = { version = "=1.0.0-rc.1", path = "../embedded-hal" }
+embedded-hal-async = { version = "=1.0.0-rc.1", path = "../embedded-hal-async", optional = true }
 critical-section = { version = "1.0" }
 defmt-03 = { package = "defmt", version = "0.3", optional = true }
 

--- a/embedded-hal-bus/README.md
+++ b/embedded-hal-bus/README.md
@@ -28,9 +28,11 @@ This crate provides mechanisms to connect a `SpiBus` and a `SpiDevice`.
 In the case of I2C, the same `I2c` `embedded-hal` trait represents either an entire bus, or a device on a bus. This crate
 provides mechanisms to obtain multiple `I2c` instances out of a single `I2c` instance, sharing the bus.
 
-## Features
+## Optional Cargo features
 
-- `std`: enable shared bus implementations using `std::sync::Mutex`.
+- **`std`**: enable shared bus implementations using `std::sync::Mutex`.
+- **`async`**: enable `embedded-hal-async` support.
+- **`defmt-03`**: Derive `defmt::Format` from `defmt` 0.3 for enums and structs.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/embedded-hal-nb/CHANGELOG.md
+++ b/embedded-hal-nb/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ...
 
+## [v1.0.0-rc.1] - 2023-08-15
+
+- Updated `embedded-hal` to version `1.0.0-rc.1`.
+- Added `+ ?Sized` to all blanket impls.
+
 ## [v1.0.0-alpha.3] - 2023-07-04
 
 ### Changed

--- a/embedded-hal-nb/Cargo.toml
+++ b/embedded-hal-nb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-hal-nb"
-version = "1.0.0-alpha.3"
+version = "1.0.0-rc.1"
 edition = "2021"
 
 categories = ["embedded", "hardware-support", "no-std"]
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
 
 [dependencies]
-embedded-hal = { version = "=1.0.0-alpha.11", path = "../embedded-hal" }
+embedded-hal = { version = "=1.0.0-rc.1", path = "../embedded-hal" }
 nb = "1"
 
 [dev-dependencies]

--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v1.0.0-rc.1] - 2023-08-15
+
+- The Minimum Supported Rust Version (MSRV) is now 1.60.0
+- Add optional `defmt` 0.3 support.
+- Remove serial traits, the replacement is the `embedded-io` crate.
+- Added `+ ?Sized` to all blanket impls.
 
 ## [v1.0.0-alpha.11] - 2023-07-04
 
@@ -65,7 +71,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 *** This is (also) an alpha release with breaking changes (sorry) ***
 
 ### Changed
-- The Minimum Supported Rust Version (MSRV) is now 1.60.0
+- The Minimum Supported Rust Version (MSRV) is now 1.59.0
 - `spi`: unify all traits into `SpiReadBus`, `SpiWriteBus` and `SpiBus` (read-write).
 - `spi`: Add `SpiDevice` trait to represent a single device in a (possibly shared) bus, with managed chip-select (CS) pin.
 - `spi`: Clarify that implementations are allowed to return before operations are finished, add `flush` to wait until finished.
@@ -291,7 +297,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.11...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-rc.1...HEAD
+[v1.0.0-rc.1]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.11...v1.0.0-rc.1
 [v1.0.0-alpha.11]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.10...v1.0.0-alpha.11
 [v1.0.0-alpha.10]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.9...v1.0.0-alpha.10
 [v1.0.0-alpha.9]: https://github.com/rust-embedded/embedded-hal/compare/v1.0.0-alpha.8...v1.0.0-alpha.9

--- a/embedded-hal/Cargo.toml
+++ b/embedded-hal/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "1.0.0-alpha.11"
+version = "1.0.0-rc.1"
 
 [dependencies]
 defmt-03 = { package = "defmt", version = "0.3", optional = true }

--- a/embedded-hal/README.md
+++ b/embedded-hal/README.md
@@ -84,6 +84,10 @@ A serial port is essentially a byte-oriented stream, and that's what `embedded-i
 with all byte streams has some advantages. For example, it allows generic code providing a command-line interface
 or a console to operate either on hardware serial ports or on virtual ones like Telnet or USB CDC-ACM.
 
+## Optional Cargo features
+
+- **`defmt-03`**: Derive `defmt::Format` from `defmt` 0.3 for enums and structs.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*

--- a/embedded-io-async/README.md
+++ b/embedded-io-async/README.md
@@ -10,6 +10,12 @@ This crate contains asynchronous versions of the [`embedded-io`](https://crates.
 
 This project is developed and maintained by the [HAL team](https://github.com/rust-embedded/wg#the-hal-team).
 
+## Optional Cargo features
+
+- **`std`**: Adds `From` impls to convert to/from `std::io` structs, adds `std::error::Error` impls.
+- **`alloc`**: Adds blanket impls for `Box`, adds `Write` impl to `Vec`.
+- **`defmt-03`**: Derive `defmt::Format` from `defmt` 0.3 for enums and structs.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate requires Rust nightly newer than `nightly-2022-11-22`, due to requiring support for

--- a/embedded-io/CHANGELOG.md
+++ b/embedded-io/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split trait adapters to the `embedded-io-adapters` crate.
 - Add `std::error` impls for `ReadExactError` & `WriteAllError`.
 - Rename trait `Io` to `ErrorKind`, for consistency with `embedded-hal`.
+- Added optional `defmt` 0.3 support.
 
 ## 0.4.0 - 2022-11-25
 

--- a/embedded-io/README.md
+++ b/embedded-io/README.md
@@ -19,6 +19,12 @@ while avoiding `dyn` or `Box`. This is consistent with how errors are handled in
 - In `std::io`, the `Read`/`Write` traits might be blocking or non-blocking (i.e. returning `WouldBlock` errors) depending on the file descriptor's mode, which is only known at run-time. This allows passing a non-blocking stream to code that expects a blocking
 stream, causing unexpected errors. To solve this, `embedded-io` specifies `Read`/`Write` are always blocking, and adds new `ReadReady`/`WriteReady` traits to allow using streams in a non-blocking way.
 
+## Optional Cargo features
+
+- **`std`**: Adds `From` impls to convert to/from `std::io` structs, adds `std::error::Error` impls.
+- **`alloc`**: Adds blanket impls for `Box`, adds `Write` impl to `Vec`.
+- **`defmt-03`**: Derive `defmt::Format` from `defmt` 0.3 for enums and structs.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*


### PR DESCRIPTION
Fixes #482 
Fixes #483 