### PR TITLE
Fix typo in embedded-io changelog

### DIFF
--- a/embedded-io/CHANGELOG.md
+++ b/embedded-io/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split async traits to the `embedded-io-async` crate.
 - Split trait adapters to the `embedded-io-adapters` crate.
 - Add `std::error` impls for `ReadExactError` & `WriteAllError`.
-- Rename trait `Io` to `ErrorKind`, for consistency with `embedded-hal`.
+- Rename trait `Io` to `ErrorType`, for consistency with `embedded-hal`.
 - Added optional `defmt` 0.3 support.
 
 ## 0.4.0 - 2022-11-25


### PR DESCRIPTION
Looks like a typo to me as ErrorKind is not a trait. 