### PR TITLE
lib: amend documents to add periods (.), add inline hints when necessary

### DIFF
--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Minor document fixes.
+- Add #[inline] hints to most of `embedded-hal-async` functions.
+
 ## [v1.0.0-rc.1] - 2023-08-15
 
 - Updated `embedded-hal` to version `1.0.0-rc.1`.

--- a/embedded-hal-async/src/delay.rs
+++ b/embedded-hal-async/src/delay.rs
@@ -1,6 +1,6 @@
-//! Delays
+//! Delays.
 
-/// Microsecond delay
+/// Microsecond delay.
 pub trait DelayUs {
     /// Pauses execution for at minimum `us` microseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
@@ -15,10 +15,12 @@ impl<T> DelayUs for &mut T
 where
     T: DelayUs + ?Sized,
 {
+    #[inline]
     async fn delay_us(&mut self, us: u32) {
         T::delay_us(self, us).await
     }
 
+    #[inline]
     async fn delay_ms(&mut self, ms: u32) {
         T::delay_ms(self, ms).await
     }

--- a/embedded-hal-async/src/digital.rs
+++ b/embedded-hal-async/src/digital.rs
@@ -1,4 +1,4 @@
-//! Asynchronous digital I/O
+//! Asynchronous digital I/O.
 //!
 //! # Example
 //!
@@ -49,22 +49,27 @@ pub trait Wait: embedded_hal::digital::ErrorType {
 }
 
 impl<T: Wait + ?Sized> Wait for &mut T {
+    #[inline]
     async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
         T::wait_for_high(self).await
     }
 
+    #[inline]
     async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
         T::wait_for_low(self).await
     }
 
+    #[inline]
     async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
         T::wait_for_rising_edge(self).await
     }
 
+    #[inline]
     async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
         T::wait_for_falling_edge(self).await
     }
 
+    #[inline]
     async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
         T::wait_for_any_edge(self).await
     }

--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -1,4 +1,4 @@
-//! Async I2C API
+//! Async I2C API.
 //!
 //! This API supports 7-bit and 10-bit addresses. Traits feature an `AddressMode`
 //! marker type parameter. Two implementation of the `AddressMode` exist:
@@ -21,9 +21,9 @@ pub use embedded_hal::i2c::{
     AddressMode, Error, ErrorKind, ErrorType, NoAcknowledgeSource, SevenBitAddress, TenBitAddress,
 };
 
-/// Async i2c
+/// Async I2c.
 pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
-    /// Reads enough bytes from slave with `address` to fill `buffer`
+    /// Reads enough bytes from slave with `address` to fill `buffer`.
     ///
     /// # I2C Events (contract)
     ///
@@ -41,12 +41,13 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `MAK` = master acknowledge
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
+    #[inline]
     async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
         self.transaction(address, &mut [Operation::Read(read)])
             .await
     }
 
-    /// Writes bytes to slave with address `address`
+    /// Writes bytes to slave with address `address`.
     ///
     /// # I2C Events (contract)
     ///
@@ -62,6 +63,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `SAK` = slave acknowledge
     /// - `Bi` = ith byte of data
     /// - `SP` = stop condition
+    #[inline]
     async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error> {
         self.transaction(address, &mut [Operation::Write(write)])
             .await
@@ -89,6 +91,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - `MAK` = master acknowledge
     /// - `NMAK` = master no acknowledge
     /// - `SP` = stop condition
+    #[inline]
     async fn write_read(
         &mut self,
         address: A,
@@ -123,14 +126,17 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
 }
 
 impl<A: AddressMode, T: I2c<A> + ?Sized> I2c<A> for &mut T {
+    #[inline]
     async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
         T::read(self, address, read).await
     }
 
+    #[inline]
     async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error> {
         T::write(self, address, write).await
     }
 
+    #[inline]
     async fn write_read(
         &mut self,
         address: A,
@@ -140,6 +146,7 @@ impl<A: AddressMode, T: I2c<A> + ?Sized> I2c<A> for &mut T {
         T::write_read(self, address, write, read).await
     }
 
+    #[inline]
     async fn transaction(
         &mut self,
         address: A,

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -4,7 +4,7 @@ pub use embedded_hal::spi::{
     Error, ErrorKind, ErrorType, Mode, Operation, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3,
 };
 
-/// SPI device trait
+/// SPI device trait.
 ///
 /// `SpiDevice` represents ownership over a single SPI device on a (possibly shared) bus, selected
 /// with a CS (Chip Select) pin.
@@ -36,6 +36,7 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     /// This is a convenience method equivalent to `device.read_transaction(&mut [buf])`.
     ///
     /// See also: [`SpiDevice::transaction`], [`SpiDevice::read`]
+    #[inline]
     async fn read(&mut self, buf: &mut [Word]) -> Result<(), Self::Error> {
         self.transaction(&mut [Operation::Read(buf)]).await
     }
@@ -45,6 +46,7 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     /// This is a convenience method equivalent to `device.write_transaction(&mut [buf])`.
     ///
     /// See also: [`SpiDevice::transaction`], [`SpiDevice::write`]
+    #[inline]
     async fn write(&mut self, buf: &[Word]) -> Result<(), Self::Error> {
         self.transaction(&mut [Operation::Write(buf)]).await
     }
@@ -54,6 +56,7 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     /// This is a convenience method equivalent to `device.transaction(|bus| bus.transfer(read, write))`.
     ///
     /// See also: [`SpiDevice::transaction`], [`SpiBus::transfer`]
+    #[inline]
     async fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error> {
         self.transaction(&mut [Operation::Transfer(read, write)])
             .await
@@ -64,6 +67,7 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     /// This is a convenience method equivalent to `device.transaction(|bus| bus.transfer_in_place(buf))`.
     ///
     /// See also: [`SpiDevice::transaction`], [`SpiBus::transfer_in_place`]
+    #[inline]
     async fn transfer_in_place(&mut self, buf: &mut [Word]) -> Result<(), Self::Error> {
         self.transaction(&mut [Operation::TransferInPlace(buf)])
             .await
@@ -71,6 +75,7 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
 }
 
 impl<Word: Copy + 'static, T: SpiDevice<Word> + ?Sized> SpiDevice<Word> for &mut T {
+    #[inline]
     async fn transaction(
         &mut self,
         operations: &mut [Operation<'_, Word>],
@@ -78,24 +83,28 @@ impl<Word: Copy + 'static, T: SpiDevice<Word> + ?Sized> SpiDevice<Word> for &mut
         T::transaction(self, operations).await
     }
 
+    #[inline]
     async fn read(&mut self, buf: &mut [Word]) -> Result<(), Self::Error> {
         T::read(self, buf).await
     }
 
+    #[inline]
     async fn write(&mut self, buf: &[Word]) -> Result<(), Self::Error> {
         T::write(self, buf).await
     }
 
+    #[inline]
     async fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error> {
         T::transfer(self, read, write).await
     }
 
+    #[inline]
     async fn transfer_in_place(&mut self, buf: &mut [Word]) -> Result<(), Self::Error> {
         T::transfer_in_place(self, buf).await
     }
 }
 
-/// SPI bus
+/// SPI bus.
 ///
 /// `SpiBus` represents **exclusive ownership** over the whole SPI bus, with SCK, MOSI and MISO pins.
 ///
@@ -110,7 +119,7 @@ pub trait SpiBus<Word: 'static + Copy = u8>: ErrorType {
     /// complete. See (the docs on embedded-hal)[embedded_hal::spi] for details on flushing.
     async fn read(&mut self, words: &mut [Word]) -> Result<(), Self::Error>;
 
-    /// Write `words` to the slave, ignoring all the incoming words
+    /// Write `words` to the slave, ignoring all the incoming words.
     ///
     /// Implementations are allowed to return before the operation is
     /// complete. See (the docs on embedded-hal)[embedded_hal::spi] for details on flushing.
@@ -144,22 +153,27 @@ pub trait SpiBus<Word: 'static + Copy = u8>: ErrorType {
 }
 
 impl<T: SpiBus<Word> + ?Sized, Word: 'static + Copy> SpiBus<Word> for &mut T {
+    #[inline]
     async fn read(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
         T::read(self, words).await
     }
 
+    #[inline]
     async fn write(&mut self, words: &[Word]) -> Result<(), Self::Error> {
         T::write(self, words).await
     }
 
+    #[inline]
     async fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error> {
         T::transfer(self, read, write).await
     }
 
+    #[inline]
     async fn transfer_in_place(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
         T::transfer_in_place(self, words).await
     }
 
+    #[inline]
     async fn flush(&mut self) -> Result<(), Self::Error> {
         T::flush(self).await
     }

--- a/embedded-hal-bus/CHANGELOG.md
+++ b/embedded-hal-bus/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Minor document fixes.
+- Add #[inline] hints to most of `embedded-hal-bus` functions.
+
 ## [v0.1.0-rc.1] - 2023-08-15
 
 - Updated `embedded-hal`, `embedded-hal-async` to version `1.0.0-rc.1`.

--- a/embedded-hal-bus/src/i2c/critical_section.rs
+++ b/embedded-hal-bus/src/i2c/critical_section.rs
@@ -14,7 +14,8 @@ pub struct CriticalSectionDevice<'a, T> {
 }
 
 impl<'a, T> CriticalSectionDevice<'a, T> {
-    /// Create a new `CriticalSectionDevice`
+    /// Create a new `CriticalSectionDevice`.
+    #[inline]
     pub fn new(bus: &'a Mutex<RefCell<T>>) -> Self {
         Self { bus }
     }
@@ -31,6 +32,7 @@ impl<'a, T> I2c for CriticalSectionDevice<'a, T>
 where
     T: I2c,
 {
+    #[inline]
     fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
         critical_section::with(|cs| {
             let bus = &mut *self.bus.borrow_ref_mut(cs);
@@ -38,6 +40,7 @@ where
         })
     }
 
+    #[inline]
     fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
         critical_section::with(|cs| {
             let bus = &mut *self.bus.borrow_ref_mut(cs);
@@ -45,6 +48,7 @@ where
         })
     }
 
+    #[inline]
     fn write_read(
         &mut self,
         address: u8,
@@ -57,6 +61,7 @@ where
         })
     }
 
+    #[inline]
     fn transaction(
         &mut self,
         address: u8,

--- a/embedded-hal-bus/src/i2c/mutex.rs
+++ b/embedded-hal-bus/src/i2c/mutex.rs
@@ -12,7 +12,8 @@ pub struct MutexDevice<'a, T> {
 }
 
 impl<'a, T> MutexDevice<'a, T> {
-    /// Create a new `MutexDevice`
+    /// Create a new `MutexDevice`.
+    #[inline]
     pub fn new(bus: &'a Mutex<T>) -> Self {
         Self { bus }
     }
@@ -29,16 +30,19 @@ impl<'a, T> I2c for MutexDevice<'a, T>
 where
     T: I2c,
 {
+    #[inline]
     fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
         let bus = &mut *self.bus.lock().unwrap();
         bus.read(address, read)
     }
 
+    #[inline]
     fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
         let bus = &mut *self.bus.lock().unwrap();
         bus.write(address, write)
     }
 
+    #[inline]
     fn write_read(
         &mut self,
         address: u8,
@@ -49,6 +53,7 @@ where
         bus.write_read(address, write, read)
     }
 
+    #[inline]
     fn transaction(
         &mut self,
         address: u8,

--- a/embedded-hal-bus/src/i2c/refcell.rs
+++ b/embedded-hal-bus/src/i2c/refcell.rs
@@ -68,7 +68,8 @@ pub struct RefCellDevice<'a, T> {
 }
 
 impl<'a, T> RefCellDevice<'a, T> {
-    /// Create a new `RefCellDevice`
+    /// Create a new `RefCellDevice`.
+    #[inline]
     pub fn new(bus: &'a RefCell<T>) -> Self {
         Self { bus }
     }
@@ -85,16 +86,19 @@ impl<'a, T> I2c for RefCellDevice<'a, T>
 where
     T: I2c,
 {
+    #[inline]
     fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
         let bus = &mut *self.bus.borrow_mut();
         bus.read(address, read)
     }
 
+    #[inline]
     fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
         let bus = &mut *self.bus.borrow_mut();
         bus.write(address, write)
     }
 
+    #[inline]
     fn write_read(
         &mut self,
         address: u8,
@@ -105,6 +109,7 @@ where
         bus.write_read(address, write, read)
     }
 
+    #[inline]
     fn transaction(
         &mut self,
         address: u8,

--- a/embedded-hal-bus/src/spi/critical_section.rs
+++ b/embedded-hal-bus/src/spi/critical_section.rs
@@ -23,7 +23,8 @@ pub struct CriticalSectionDevice<'a, BUS, CS, D> {
 }
 
 impl<'a, BUS, CS, D> CriticalSectionDevice<'a, BUS, CS, D> {
-    /// Create a new ExclusiveDevice
+    /// Create a new ExclusiveDevice.
+    #[inline]
     pub fn new(bus: &'a Mutex<RefCell<BUS>>, cs: CS, delay: D) -> Self {
         Self { bus, cs, delay }
     }
@@ -36,6 +37,7 @@ impl<'a, BUS, CS> CriticalSectionDevice<'a, BUS, CS, super::NoDelay> {
     ///
     /// The returned device will panic if you try to execute a transaction
     /// that contains any operations of type `Operation::DelayUs`.
+    #[inline]
     pub fn new_no_delay(bus: &'a Mutex<RefCell<BUS>>, cs: CS) -> Self {
         Self {
             bus,
@@ -59,6 +61,7 @@ where
     CS: OutputPin,
     D: DelayUs,
 {
+    #[inline]
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {
         critical_section::with(|cs| {
             let bus = &mut *self.bus.borrow_ref_mut(cs);

--- a/embedded-hal-bus/src/spi/exclusive.rs
+++ b/embedded-hal-bus/src/spi/exclusive.rs
@@ -22,17 +22,20 @@ pub struct ExclusiveDevice<BUS, CS, D> {
 }
 
 impl<BUS, CS, D> ExclusiveDevice<BUS, CS, D> {
-    /// Create a new ExclusiveDevice
+    /// Create a new ExclusiveDevice.
+    #[inline]
     pub fn new(bus: BUS, cs: CS, delay: D) -> Self {
         Self { bus, cs, delay }
     }
 
     /// Returns a reference to the underlying bus object.
+    #[inline]
     pub fn bus(&self) -> &BUS {
         &self.bus
     }
 
     /// Returns a mutable reference to the underlying bus object.
+    #[inline]
     pub fn bus_mut(&mut self) -> &mut BUS {
         &mut self.bus
     }
@@ -45,6 +48,7 @@ impl<BUS, CS> ExclusiveDevice<BUS, CS, super::NoDelay> {
     ///
     /// The returned device will panic if you try to execute a transaction
     /// that contains any operations of type `Operation::DelayUs`.
+    #[inline]
     pub fn new_no_delay(bus: BUS, cs: CS) -> Self {
         Self {
             bus,
@@ -68,6 +72,7 @@ where
     CS: OutputPin,
     D: DelayUs,
 {
+    #[inline]
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {
         self.cs.set_low().map_err(DeviceError::Cs)?;
 
@@ -103,6 +108,7 @@ where
     CS: OutputPin,
     D: AsyncDelayUs,
 {
+    #[inline]
     async fn transaction(
         &mut self,
         operations: &mut [Operation<'_, Word>],

--- a/embedded-hal-bus/src/spi/mod.rs
+++ b/embedded-hal-bus/src/spi/mod.rs
@@ -21,9 +21,9 @@ use crate::defmt;
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum DeviceError<BUS, CS> {
-    /// An inner SPI bus operation failed
+    /// An inner SPI bus operation failed.
     Spi(BUS),
-    /// Asserting or deasserting CS failed
+    /// Asserting or deasserting CS failed.
     Cs(CS),
 }
 
@@ -32,6 +32,7 @@ where
     BUS: Error + Debug,
     CS: Debug,
 {
+    #[inline]
     fn kind(&self) -> ErrorKind {
         match self {
             Self::Spi(e) => e.kind(),
@@ -51,6 +52,7 @@ fn no_delay_panic() {
 }
 
 impl embedded_hal::delay::DelayUs for NoDelay {
+    #[inline]
     fn delay_us(&mut self, _us: u32) {
         no_delay_panic();
     }
@@ -59,11 +61,13 @@ impl embedded_hal::delay::DelayUs for NoDelay {
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 impl embedded_hal_async::delay::DelayUs for NoDelay {
+    #[inline]
     async fn delay_us(&mut self, _us: u32) {
         no_delay_panic();
     }
 
-    async fn delay_ms(&mut self, _us: u32) {
+    #[inline]
+    async fn delay_ms(&mut self, _ms: u32) {
         no_delay_panic();
     }
 }

--- a/embedded-hal-bus/src/spi/mutex.rs
+++ b/embedded-hal-bus/src/spi/mutex.rs
@@ -21,7 +21,8 @@ pub struct MutexDevice<'a, BUS, CS, D> {
 }
 
 impl<'a, BUS, CS, D> MutexDevice<'a, BUS, CS, D> {
-    /// Create a new ExclusiveDevice
+    /// Create a new MutexDevice.
+    #[inline]
     pub fn new(bus: &'a Mutex<BUS>, cs: CS, delay: D) -> Self {
         Self { bus, cs, delay }
     }
@@ -34,6 +35,7 @@ impl<'a, BUS, CS> MutexDevice<'a, BUS, CS, super::NoDelay> {
     ///
     /// The returned device will panic if you try to execute a transaction
     /// that contains any operations of type `Operation::DelayUs`.
+    #[inline]
     pub fn new_no_delay(bus: &'a Mutex<BUS>, cs: CS) -> Self {
         Self {
             bus,
@@ -57,6 +59,7 @@ where
     CS: OutputPin,
     D: DelayUs,
 {
+    #[inline]
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {
         let bus = &mut *self.bus.lock().unwrap();
 

--- a/embedded-hal-bus/src/spi/refcell.rs
+++ b/embedded-hal-bus/src/spi/refcell.rs
@@ -20,7 +20,8 @@ pub struct RefCellDevice<'a, BUS, CS, D> {
 }
 
 impl<'a, BUS, CS, D> RefCellDevice<'a, BUS, CS, D> {
-    /// Create a new ExclusiveDevice
+    /// Create a new RefCellDevice.
+    #[inline]
     pub fn new(bus: &'a RefCell<BUS>, cs: CS, delay: D) -> Self {
         Self { bus, cs, delay }
     }
@@ -33,6 +34,7 @@ impl<'a, BUS, CS> RefCellDevice<'a, BUS, CS, super::NoDelay> {
     ///
     /// The returned device will panic if you try to execute a transaction
     /// that contains any operations of type `Operation::DelayUs`.
+    #[inline]
     pub fn new_no_delay(bus: &'a RefCell<BUS>, cs: CS) -> Self {
         Self {
             bus,
@@ -56,6 +58,7 @@ where
     CS: OutputPin,
     D: DelayUs,
 {
+    #[inline]
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {
         let bus = &mut *self.bus.borrow_mut();
 

--- a/embedded-hal-nb/CHANGELOG.md
+++ b/embedded-hal-nb/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+- Minor document fixes.
+- Add #[inline] hints to most of `embedded-hal-nb` functions.
 
 ## [v1.0.0-rc.1] - 2023-08-15
 

--- a/embedded-hal-nb/src/serial.rs
+++ b/embedded-hal-nb/src/serial.rs
@@ -1,6 +1,6 @@
-//! Serial interface
+//! Serial interface.
 
-/// Serial error
+/// Serial error.
 pub trait Error: core::fmt::Debug {
     /// Convert error to a generic serial error kind
     ///
@@ -11,12 +11,13 @@ pub trait Error: core::fmt::Debug {
 }
 
 impl Error for core::convert::Infallible {
+    #[inline]
     fn kind(&self) -> ErrorKind {
         match *self {}
     }
 }
 
-/// Serial error kind
+/// Serial error kind.
 ///
 /// This represents a common set of serial operation errors. HAL implementations are
 /// free to define more specific or additional error types. However, by providing
@@ -38,12 +39,14 @@ pub enum ErrorKind {
 }
 
 impl Error for ErrorKind {
+    #[inline]
     fn kind(&self) -> ErrorKind {
         *self
     }
 }
 
 impl core::fmt::Display for ErrorKind {
+    #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Overrun => write!(f, "The peripheral receive buffer was overrun"),
@@ -61,7 +64,7 @@ impl core::fmt::Display for ErrorKind {
     }
 }
 
-/// Serial error type trait
+/// Serial error type trait.
 ///
 /// This just defines the error type, to be used by the other traits.
 pub trait ErrorType {
@@ -73,7 +76,7 @@ impl<T: ErrorType + ?Sized> ErrorType for &mut T {
     type Error = T::Error;
 }
 
-/// Read half of a serial interface
+/// Read half of a serial interface.
 ///
 /// Some serial interfaces support different data sizes (8 bits, 9 bits, etc.);
 /// This can be encoded in this trait via the `Word` type parameter.
@@ -83,25 +86,28 @@ pub trait Read<Word: Copy = u8>: ErrorType {
 }
 
 impl<T: Read<Word> + ?Sized, Word: Copy> Read<Word> for &mut T {
+    #[inline]
     fn read(&mut self) -> nb::Result<Word, Self::Error> {
         T::read(self)
     }
 }
 
-/// Write half of a serial interface
+/// Write half of a serial interface.
 pub trait Write<Word: Copy = u8>: ErrorType {
-    /// Writes a single word to the serial interface
+    /// Writes a single word to the serial interface.
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error>;
 
-    /// Ensures that none of the previously written words are still buffered
+    /// Ensures that none of the previously written words are still buffered.
     fn flush(&mut self) -> nb::Result<(), Self::Error>;
 }
 
 impl<T: Write<Word> + ?Sized, Word: Copy> Write<Word> for &mut T {
+    #[inline]
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error> {
         T::write(self, word)
     }
 
+    #[inline]
     fn flush(&mut self) -> nb::Result<(), Self::Error> {
         T::flush(self)
     }
@@ -115,6 +121,7 @@ impl<Word, Error: self::Error> core::fmt::Write for dyn Write<Word, Error = Erro
 where
     Word: Copy + From<u8>,
 {
+    #[inline]
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         let _ = s
             .bytes()

--- a/embedded-hal-nb/src/spi.rs
+++ b/embedded-hal-nb/src/spi.rs
@@ -4,11 +4,11 @@ pub use embedded_hal::spi::{
     Error, ErrorKind, ErrorType, Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3,
 };
 
-/// Full duplex SPI (master mode)
+/// Full duplex SPI (master mode).
 ///
 /// # Notes
 ///
-/// - It's the task of the user of this interface to manage the slave select lines
+/// - It's the task of the user of this interface to manage the slave select lines.
 ///
 /// - Due to how full duplex SPI works each `read` call must be preceded by a `write` call.
 ///
@@ -32,10 +32,12 @@ pub trait FullDuplex<Word: Copy = u8>: ErrorType {
 }
 
 impl<T: FullDuplex<Word> + ?Sized, Word: Copy> FullDuplex<Word> for &mut T {
+    #[inline]
     fn read(&mut self) -> nb::Result<Word, Self::Error> {
         T::read(self)
     }
 
+    #[inline]
     fn write(&mut self, word: Word) -> nb::Result<(), Self::Error> {
         T::write(self, word)
     }

--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Minor document fixes.
+- Add #[inline] hints to most of `embedded-hal` functions.
+
 ## [v1.0.0-rc.1] - 2023-08-15
 
 - The Minimum Supported Rust Version (MSRV) is now 1.60.0

--- a/embedded-hal/src/delay.rs
+++ b/embedded-hal/src/delay.rs
@@ -1,7 +1,6 @@
-//! Delays
+//! Delays.
 
-/// Microsecond delay
-///
+/// Microsecond delay.
 pub trait DelayUs {
     /// Pauses execution for at minimum `us` microseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
@@ -9,6 +8,7 @@ pub trait DelayUs {
 
     /// Pauses execution for at minimum `ms` milliseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
+    #[inline]
     fn delay_ms(&mut self, ms: u32) {
         for _ in 0..ms {
             self.delay_us(1000);
@@ -20,10 +20,12 @@ impl<T> DelayUs for &mut T
 where
     T: DelayUs + ?Sized,
 {
+    #[inline]
     fn delay_us(&mut self, us: u32) {
         T::delay_us(self, us)
     }
 
+    #[inline]
     fn delay_ms(&mut self, ms: u32) {
         T::delay_ms(self, ms)
     }

--- a/embedded-hal/src/digital.rs
+++ b/embedded-hal/src/digital.rs
@@ -1,11 +1,11 @@
-//! Digital I/O
+//! Digital I/O.
 
 use core::{convert::From, ops::Not};
 
 #[cfg(feature = "defmt-03")]
 use crate::defmt;
 
-/// Error
+/// Error.
 pub trait Error: core::fmt::Debug {
     /// Convert error to a generic error kind
     ///
@@ -21,7 +21,7 @@ impl Error for core::convert::Infallible {
     }
 }
 
-/// Error kind
+/// Error kind.
 ///
 /// This represents a common set of operation errors. HAL implementations are
 /// free to define more specific or additional error types. However, by providing
@@ -35,12 +35,14 @@ pub enum ErrorKind {
 }
 
 impl Error for ErrorKind {
+    #[inline]
     fn kind(&self) -> ErrorKind {
         *self
     }
 }
 
 impl core::fmt::Display for ErrorKind {
+    #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Other => write!(
@@ -51,7 +53,7 @@ impl core::fmt::Display for ErrorKind {
     }
 }
 
-/// Error type trait
+/// Error type trait.
 ///
 /// This just defines the error type, to be used by the other traits.
 pub trait ErrorType {
@@ -67,7 +69,7 @@ impl<T: ErrorType + ?Sized> ErrorType for &mut T {
     type Error = T::Error;
 }
 
-/// Digital output pin state
+/// Digital output pin state.
 ///
 /// Conversion from `bool` and logical negation are also implemented
 /// for this type.
@@ -80,9 +82,9 @@ impl<T: ErrorType + ?Sized> ErrorType for &mut T {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum PinState {
-    /// Low pin state
+    /// Low pin state.
     Low,
-    /// High pin state
+    /// High pin state.
     High,
 }
 
@@ -118,24 +120,25 @@ impl From<PinState> for bool {
     }
 }
 
-/// Single digital push-pull output pin
+/// Single digital push-pull output pin.
 pub trait OutputPin: ErrorType {
-    /// Drives the pin low
+    /// Drives the pin low.
     ///
     /// *NOTE* the actual electrical state of the pin may not actually be low, e.g. due to external
-    /// electrical sources
+    /// electrical sources.
     fn set_low(&mut self) -> Result<(), Self::Error>;
 
-    /// Drives the pin high
+    /// Drives the pin high.
     ///
     /// *NOTE* the actual electrical state of the pin may not actually be high, e.g. due to external
-    /// electrical sources
+    /// electrical sources.
     fn set_high(&mut self) -> Result<(), Self::Error>;
 
-    /// Drives the pin high or low depending on the provided value
+    /// Drives the pin high or low depending on the provided value.
     ///
     /// *NOTE* the actual electrical state of the pin may not actually be high or low, e.g. due to external
-    /// electrical sources
+    /// electrical sources.
+    #[inline]
     fn set_state(&mut self, state: PinState) -> Result<(), Self::Error> {
         match state {
             PinState::Low => self.set_low(),
@@ -145,55 +148,61 @@ pub trait OutputPin: ErrorType {
 }
 
 impl<T: OutputPin + ?Sized> OutputPin for &mut T {
+    #[inline]
     fn set_low(&mut self) -> Result<(), Self::Error> {
         T::set_low(self)
     }
 
+    #[inline]
     fn set_high(&mut self) -> Result<(), Self::Error> {
         T::set_high(self)
     }
 
+    #[inline]
     fn set_state(&mut self, state: PinState) -> Result<(), Self::Error> {
         T::set_state(self, state)
     }
 }
 
-/// Push-pull output pin that can read its output state
+/// Push-pull output pin that can read its output state.
 pub trait StatefulOutputPin: OutputPin {
     /// Is the pin in drive high mode?
     ///
-    /// *NOTE* this does *not* read the electrical state of the pin
+    /// *NOTE* this does *not* read the electrical state of the pin.
     fn is_set_high(&self) -> Result<bool, Self::Error>;
 
     /// Is the pin in drive low mode?
     ///
-    /// *NOTE* this does *not* read the electrical state of the pin
+    /// *NOTE* this does *not* read the electrical state of the pin.
     fn is_set_low(&self) -> Result<bool, Self::Error>;
 }
 
 impl<T: StatefulOutputPin + ?Sized> StatefulOutputPin for &mut T {
+    #[inline]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         T::is_set_high(self)
     }
 
+    #[inline]
     fn is_set_low(&self) -> Result<bool, Self::Error> {
         T::is_set_low(self)
     }
 }
 
-/// Output pin that can be toggled
+/// Output pin that can be toggled.
 pub trait ToggleableOutputPin: ErrorType {
     /// Toggle pin output.
     fn toggle(&mut self) -> Result<(), Self::Error>;
 }
 
 impl<T: ToggleableOutputPin + ?Sized> ToggleableOutputPin for &mut T {
+    #[inline]
     fn toggle(&mut self) -> Result<(), Self::Error> {
         T::toggle(self)
     }
 }
 
-/// Single digital input pin
+/// Single digital input pin.
 pub trait InputPin: ErrorType {
     /// Is the input pin high?
     fn is_high(&self) -> Result<bool, Self::Error>;
@@ -203,10 +212,12 @@ pub trait InputPin: ErrorType {
 }
 
 impl<T: InputPin + ?Sized> InputPin for &T {
+    #[inline]
     fn is_high(&self) -> Result<bool, Self::Error> {
         T::is_high(self)
     }
 
+    #[inline]
     fn is_low(&self) -> Result<bool, Self::Error> {
         T::is_low(self)
     }

--- a/embedded-hal/src/pwm.rs
+++ b/embedded-hal/src/pwm.rs
@@ -1,11 +1,11 @@
-//! Pulse Width Modulation (PWM) traits
+//! Pulse Width Modulation (PWM) traits.
 
 #[cfg(feature = "defmt-03")]
 use crate::defmt;
 
 /// Error
 pub trait Error: core::fmt::Debug {
-    /// Convert error to a generic error kind
+    /// Convert error to a generic error kind.
     ///
     /// By using this method, errors freely defined by HAL implementations
     /// can be converted to a set of generic errors upon which generic
@@ -14,12 +14,13 @@ pub trait Error: core::fmt::Debug {
 }
 
 impl Error for core::convert::Infallible {
+    #[inline]
     fn kind(&self) -> ErrorKind {
         match *self {}
     }
 }
 
-/// Error kind
+/// Error kind.
 ///
 /// This represents a common set of operation errors. HAL implementations are
 /// free to define more specific or additional error types. However, by providing
@@ -33,12 +34,14 @@ pub enum ErrorKind {
 }
 
 impl Error for ErrorKind {
+    #[inline]
     fn kind(&self) -> ErrorKind {
         *self
     }
 }
 
 impl core::fmt::Display for ErrorKind {
+    #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Other => write!(
@@ -49,7 +52,7 @@ impl core::fmt::Display for ErrorKind {
     }
 }
 
-/// Error type trait
+/// Error type trait.
 ///
 /// This just defines the error type, to be used by the other traits.
 pub trait ErrorType {
@@ -61,7 +64,7 @@ impl<T: ErrorType + ?Sized> ErrorType for &mut T {
     type Error = T::Error;
 }
 
-/// Single PWM channel / pin
+/// Single PWM channel / pin.
 pub trait SetDutyCycle: ErrorType {
     /// Get the maximum duty cycle value.
     ///
@@ -106,26 +109,32 @@ pub trait SetDutyCycle: ErrorType {
 }
 
 impl<T: SetDutyCycle + ?Sized> SetDutyCycle for &mut T {
+    #[inline]
     fn get_max_duty_cycle(&self) -> u16 {
         T::get_max_duty_cycle(self)
     }
 
+    #[inline]
     fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
         T::set_duty_cycle(self, duty)
     }
 
+    #[inline]
     fn set_duty_cycle_fully_off(&mut self) -> Result<(), Self::Error> {
         T::set_duty_cycle_fully_off(self)
     }
 
+    #[inline]
     fn set_duty_cycle_fully_on(&mut self) -> Result<(), Self::Error> {
         T::set_duty_cycle_fully_on(self)
     }
 
+    #[inline]
     fn set_duty_cycle_fraction(&mut self, num: u16, denom: u16) -> Result<(), Self::Error> {
         T::set_duty_cycle_fraction(self, num, denom)
     }
 
+    #[inline]
     fn set_duty_cycle_percent(&mut self, percent: u8) -> Result<(), Self::Error> {
         T::set_duty_cycle_percent(self, percent)
     }

--- a/embedded-hal/src/spi.rs
+++ b/embedded-hal/src/spi.rs
@@ -166,63 +166,63 @@ use core::fmt::Debug;
 #[cfg(feature = "defmt-03")]
 use crate::defmt;
 
-/// Clock polarity
+/// Clock polarity.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Polarity {
-    /// Clock signal low when idle
+    /// Clock signal low when idle.
     IdleLow,
-    /// Clock signal high when idle
+    /// Clock signal high when idle.
     IdleHigh,
 }
 
-/// Clock phase
+/// Clock phase.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Phase {
-    /// Data in "captured" on the first clock transition
+    /// Data in "captured" on the first clock transition.
     CaptureOnFirstTransition,
-    /// Data in "captured" on the second clock transition
+    /// Data in "captured" on the second clock transition.
     CaptureOnSecondTransition,
 }
 
-/// SPI mode
+/// SPI mode.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct Mode {
-    /// Clock polarity
+    /// Clock polarity.
     pub polarity: Polarity,
-    /// Clock phase
+    /// Clock phase.
     pub phase: Phase,
 }
 
-/// Helper for CPOL = 0, CPHA = 0
+/// Helper for CPOL = 0, CPHA = 0.
 pub const MODE_0: Mode = Mode {
     polarity: Polarity::IdleLow,
     phase: Phase::CaptureOnFirstTransition,
 };
 
-/// Helper for CPOL = 0, CPHA = 1
+/// Helper for CPOL = 0, CPHA = 1.
 pub const MODE_1: Mode = Mode {
     polarity: Polarity::IdleLow,
     phase: Phase::CaptureOnSecondTransition,
 };
 
-/// Helper for CPOL = 1, CPHA = 0
+/// Helper for CPOL = 1, CPHA = 0.
 pub const MODE_2: Mode = Mode {
     polarity: Polarity::IdleHigh,
     phase: Phase::CaptureOnFirstTransition,
 };
 
-/// Helper for CPOL = 1, CPHA = 1
+/// Helper for CPOL = 1, CPHA = 1.
 pub const MODE_3: Mode = Mode {
     polarity: Polarity::IdleHigh,
     phase: Phase::CaptureOnSecondTransition,
 };
 
-/// SPI error
+/// SPI error.
 pub trait Error: core::fmt::Debug {
-    /// Convert error to a generic SPI error kind
+    /// Convert error to a generic SPI error kind.
     ///
     /// By using this method, SPI errors freely defined by HAL implementations
     /// can be converted to a set of generic SPI errors upon which generic
@@ -231,12 +231,13 @@ pub trait Error: core::fmt::Debug {
 }
 
 impl Error for core::convert::Infallible {
+    #[inline]
     fn kind(&self) -> ErrorKind {
         match *self {}
     }
 }
 
-/// SPI error kind
+/// SPI error kind.
 ///
 /// This represents a common set of SPI operation errors. HAL implementations are
 /// free to define more specific or additional error types. However, by providing
@@ -245,11 +246,11 @@ impl Error for core::convert::Infallible {
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum ErrorKind {
-    /// The peripheral receive buffer was overrun
+    /// The peripheral receive buffer was overrun.
     Overrun,
-    /// Multiple devices on the SPI bus are trying to drive the slave select pin, e.g. in a multi-master setup
+    /// Multiple devices on the SPI bus are trying to drive the slave select pin, e.g. in a multi-master setup.
     ModeFault,
-    /// Received data does not conform to the peripheral configuration
+    /// Received data does not conform to the peripheral configuration.
     FrameFormat,
     /// An error occurred while asserting or deasserting the Chip Select pin.
     ChipSelectFault,
@@ -258,12 +259,14 @@ pub enum ErrorKind {
 }
 
 impl Error for ErrorKind {
+    #[inline]
     fn kind(&self) -> ErrorKind {
         *self
     }
 }
 
 impl core::fmt::Display for ErrorKind {
+    #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Overrun => write!(f, "The peripheral receive buffer was overrun"),
@@ -287,11 +290,11 @@ impl core::fmt::Display for ErrorKind {
     }
 }
 
-/// SPI error type trait
+/// SPI error type trait.
 ///
 /// This just defines the error type, to be used by the other SPI traits.
 pub trait ErrorType {
-    /// Error type
+    /// Error type.
     type Error: Error;
 }
 
@@ -301,7 +304,7 @@ impl<T: ErrorType + ?Sized> ErrorType for &mut T {
 
 /// SPI transaction operation.
 ///
-/// This allows composition of SPI operations into a single bus transaction
+/// This allows composition of SPI operations into a single bus transaction.
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Operation<'a, Word: 'static> {
@@ -309,7 +312,7 @@ pub enum Operation<'a, Word: 'static> {
     ///
     /// Equivalent to [`SpiBus::read`].
     Read(&'a mut [Word]),
-    /// Write data from the provided buffer, discarding read data
+    /// Write data from the provided buffer, discarding read data.
     ///
     /// Equivalent to [`SpiBus::write`].
     Write(&'a [Word]),
@@ -317,15 +320,15 @@ pub enum Operation<'a, Word: 'static> {
     ///
     /// Equivalent to [`SpiBus::transfer`].
     Transfer(&'a mut [Word], &'a [Word]),
-    /// Write data out while reading data into the provided buffer
+    /// Write data out while reading data into the provided buffer.
     ///
     /// Equivalent to [`SpiBus::transfer_in_place`].
     TransferInPlace(&'a mut [Word]),
-    /// Delay for at least the specified number of microseconds
+    /// Delay for at least the specified number of microseconds.
     DelayUs(u32),
 }
 
-/// SPI device trait
+/// SPI device trait.
 ///
 /// `SpiDevice` represents ownership over a single SPI device on a (possibly shared) bus, selected
 /// with a CS (Chip Select) pin.
@@ -354,6 +357,7 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     /// This is a convenience method equivalent to `device.transaction(&mut [Operation::Read(buf)])`.
     ///
     /// See also: [`SpiDevice::transaction`], [`SpiBus::read`]
+    #[inline]
     fn read(&mut self, buf: &mut [Word]) -> Result<(), Self::Error> {
         self.transaction(&mut [Operation::Read(buf)])
     }
@@ -363,6 +367,7 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     /// This is a convenience method equivalent to `device.transaction(&mut [Operation::Write(buf)])`.
     ///
     /// See also: [`SpiDevice::transaction`], [`SpiBus::write`]
+    #[inline]
     fn write(&mut self, buf: &[Word]) -> Result<(), Self::Error> {
         self.transaction(&mut [Operation::Write(buf)])
     }
@@ -372,6 +377,7 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     /// This is a convenience method equivalent to `device.transaction(&mut [Operation::Transfer(read, write)]`.
     ///
     /// See also: [`SpiDevice::transaction`], [`SpiBus::transfer`]
+    #[inline]
     fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error> {
         self.transaction(&mut [Operation::Transfer(read, write)])
     }
@@ -381,34 +387,40 @@ pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     /// This is a convenience method equivalent to `device.transaction(&mut [Operation::TransferInPlace(buf)]`.
     ///
     /// See also: [`SpiDevice::transaction`], [`SpiBus::transfer_in_place`]
+    #[inline]
     fn transfer_in_place(&mut self, buf: &mut [Word]) -> Result<(), Self::Error> {
         self.transaction(&mut [Operation::TransferInPlace(buf)])
     }
 }
 
 impl<Word: Copy + 'static, T: SpiDevice<Word> + ?Sized> SpiDevice<Word> for &mut T {
+    #[inline]
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {
         T::transaction(self, operations)
     }
 
+    #[inline]
     fn read(&mut self, buf: &mut [Word]) -> Result<(), Self::Error> {
         T::read(self, buf)
     }
 
+    #[inline]
     fn write(&mut self, buf: &[Word]) -> Result<(), Self::Error> {
         T::write(self, buf)
     }
 
+    #[inline]
     fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error> {
         T::transfer(self, read, write)
     }
 
+    #[inline]
     fn transfer_in_place(&mut self, buf: &mut [Word]) -> Result<(), Self::Error> {
         T::transfer_in_place(self, buf)
     }
 }
 
-/// SPI bus
+/// SPI bus.
 ///
 /// `SpiBus` represents **exclusive ownership** over the whole SPI bus, with SCK, MOSI and MISO pins.
 ///
@@ -423,7 +435,7 @@ pub trait SpiBus<Word: Copy + 'static = u8>: ErrorType {
     /// complete. See the [module-level documentation](self) for details.
     fn read(&mut self, words: &mut [Word]) -> Result<(), Self::Error>;
 
-    /// Write `words` to the slave, ignoring all the incoming words
+    /// Write `words` to the slave, ignoring all the incoming words.
     ///
     /// Implementations are allowed to return before the operation is
     /// complete. See the [module-level documentation](self) for details.
@@ -457,22 +469,27 @@ pub trait SpiBus<Word: Copy + 'static = u8>: ErrorType {
 }
 
 impl<T: SpiBus<Word> + ?Sized, Word: Copy + 'static> SpiBus<Word> for &mut T {
+    #[inline]
     fn read(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
         T::read(self, words)
     }
 
+    #[inline]
     fn write(&mut self, words: &[Word]) -> Result<(), Self::Error> {
         T::write(self, words)
     }
 
+    #[inline]
     fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error> {
         T::transfer(self, read, write)
     }
 
+    #[inline]
     fn transfer_in_place(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
         T::transfer_in_place(self, words)
     }
 
+    #[inline]
     fn flush(&mut self) -> Result<(), Self::Error> {
         T::flush(self)
     }


### PR DESCRIPTION
In documentation style of the Rust standard library, first sentence of all modules, types, and functions documentation has a period. We follow Rust standard library style to make it easier for users to read.

Most of functions in embedded-hal{,-async,-bus,-nb} (especially type conversations, function fowarding calls) are now marked #[inline] to allow further optimizations.

Those changes affects embedded-hal, embedded-hal-async, embedded-hal-bus and embedded-hal-nb.

Note: there are multiple commits for each commit changes an amount of files of certain module. If that's not the case, please reply and I'll squash the commits.