### PR TITLE
Implement from custom write errors for Infallible

### DIFF
--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -3,7 +3,7 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
-use core::fmt;
+use core::{convert::Infallible, fmt};
 
 // needed to prevent defmt macros from breaking, since they emit code that does `defmt::blahblah`.
 #[cfg(feature = "defmt-03")]
@@ -289,6 +289,16 @@ impl<E> From<E> for WriteFmtError<E> {
     }
 }
 
+impl From<WriteFmtError<Infallible>> for Infallible {
+    fn from(err: WriteFmtError<Infallible>) -> Self {
+        match err {
+            WriteFmtError::WriteZero => panic!("Infallible zero write"),
+            WriteFmtError::FmtError => panic!("Infallible fmt write"),
+            WriteFmtError::Other(e) => e,
+        }
+    }
+}
+
 impl<E: fmt::Debug> fmt::Display for WriteFmtError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)
@@ -312,6 +322,15 @@ pub enum WriteAllError<E> {
 impl<E> From<E> for WriteAllError<E> {
     fn from(err: E) -> Self {
         Self::Other(err)
+    }
+}
+
+impl From<WriteAllError<Infallible>> for Infallible {
+    fn from(err: WriteAllError<Infallible>) -> Self {
+        match err {
+            WriteAllError::WriteZero => panic!("Infallible zero write"),
+            WriteAllError::Other(e) => e,
+        }
     }
 }
 


### PR DESCRIPTION
This PR will allow io middleware to constrain their `Write` implementation to a restricted error type that can convert from the new `WriteAllError`/`WriteFmtError` types. One example is the proposal over here: https://github.com/rmja/buffered-io/blob/constrained-write-error/src/asynch/write.rs#L28-L30

Specifically, it allows for easy use of e.g. Vec in tests which has the `Infallible` error type.

For reference, see the discussions here:
* https://github.com/drogue-iot/reqwless/pull/39
* https://matrix.to/#/!YoLPkieCYHGzdjUhOK:matrix.org/$ghiVYOEf6MqDoMNFUiOQmcW82cHPjVeKsVBPGRIGoZ0?via=matrix.org&via=grusbv.com&via=tchncs.de

And, please, let me know if there is anything obvious that I am missing that could easy the transition to handling these two new error types.

cc @lulf @Dirbaio @MabezDev 
