### PR TITLE
Inline a few format args for readability

### DIFF
--- a/embedded-io-adapters/src/std.rs
+++ b/embedded-io-adapters/src/std.rs
@@ -118,5 +118,5 @@ impl<T: embedded_io::Seek + ?Sized> std::io::Seek for ToStd<T> {
 
 /// Convert a embedded-io error to a std::io::Error
 pub fn to_std_error<T: embedded_io::Error>(err: T) -> std::io::Error {
-    std::io::Error::new(err.kind().into(), format!("{:?}", err))
+    std::io::Error::new(err.kind().into(), format!("{err:?}"))
 }

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -243,7 +243,7 @@ impl From<ReadExactError<std::io::Error>> for std::io::Error {
                 std::io::ErrorKind::UnexpectedEof,
                 "UnexpectedEof".to_owned(),
             ),
-            ReadExactError::Other(e) => std::io::Error::new(e.kind(), format!("{:?}", e)),
+            ReadExactError::Other(e) => std::io::Error::new(e.kind(), format!("{e:?}")),
         }
     }
 }
@@ -256,14 +256,14 @@ impl From<WriteAllError<std::io::Error>> for std::io::Error {
             WriteAllError::WriteZero => {
                 std::io::Error::new(std::io::ErrorKind::WriteZero, "WriteZero".to_owned())
             }
-            WriteAllError::Other(e) => std::io::Error::new(e.kind(), format!("{:?}", e)),
+            WriteAllError::Other(e) => std::io::Error::new(e.kind(), format!("{e:?}")),
         }
     }
 }
 
 impl<E: fmt::Debug> fmt::Display for ReadExactError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -291,7 +291,7 @@ impl<E> From<E> for WriteFmtError<E> {
 
 impl<E: fmt::Debug> fmt::Display for WriteFmtError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -317,7 +317,7 @@ impl<E> From<E> for WriteAllError<E> {
 
 impl<E: fmt::Debug> fmt::Display for WriteAllError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 


### PR DESCRIPTION
This existed since 1.58, so safe for MSRV