### PR TITLE
Fix doc links and one incorrect type name

### DIFF
--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -9,7 +9,7 @@ pub use embedded_hal::spi::{
 /// `SpiDevice` represents ownership over a single SPI device on a (possibly shared) bus, selected
 /// with a CS (Chip Select) pin.
 ///
-/// See (the docs on embedded-hal)[embedded_hal::spi] for important information on SPI Bus vs Device traits.
+/// See [the docs on embedded-hal](embedded_hal::spi) for important information on SPI Bus vs Device traits.
 pub trait SpiDevice<Word: Copy + 'static = u8>: ErrorType {
     /// Perform a transaction against the device.
     ///
@@ -108,7 +108,7 @@ impl<Word: Copy + 'static, T: SpiDevice<Word> + ?Sized> SpiDevice<Word> for &mut
 ///
 /// `SpiBus` represents **exclusive ownership** over the whole SPI bus, with SCK, MOSI and MISO pins.
 ///
-/// See (the docs on embedded-hal)[embedded_hal::spi] for important information on SPI Bus vs Device traits.
+/// See [the docs on embedded-hal][embedded_hal::spi] for important information on SPI Bus vs Device traits.
 pub trait SpiBus<Word: 'static + Copy = u8>: ErrorType {
     /// Read `words` from the slave.
     ///
@@ -116,13 +116,13 @@ pub trait SpiBus<Word: 'static + Copy = u8>: ErrorType {
     /// typically `0x00`, `0xFF`, or configurable.
     ///
     /// Implementations are allowed to return before the operation is
-    /// complete. See (the docs on embedded-hal)[embedded_hal::spi] for details on flushing.
+    /// complete. See [the docs on embedded-hal][embedded_hal::spi] for details on flushing.
     async fn read(&mut self, words: &mut [Word]) -> Result<(), Self::Error>;
 
     /// Write `words` to the slave, ignoring all the incoming words.
     ///
     /// Implementations are allowed to return before the operation is
-    /// complete. See (the docs on embedded-hal)[embedded_hal::spi] for details on flushing.
+    /// complete. See [the docs on embedded-hal][embedded_hal::spi] for details on flushing.
     async fn write(&mut self, words: &[Word]) -> Result<(), Self::Error>;
 
     /// Write and read simultaneously. `write` is written to the slave on MOSI and
@@ -135,7 +135,7 @@ pub trait SpiBus<Word: 'static + Copy = u8>: ErrorType {
     /// typically `0x00`, `0xFF`, or configurable.
     ///
     /// Implementations are allowed to return before the operation is
-    /// complete. See (the docs on embedded-hal)[embedded_hal::spi] for details on flushing.
+    /// complete. See [the docs on embedded-hal][embedded_hal::spi] for details on flushing.
     async fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error>;
 
     /// Write and read simultaneously. The contents of `words` are
@@ -143,12 +143,12 @@ pub trait SpiBus<Word: 'static + Copy = u8>: ErrorType {
     /// `words` buffer, overwriting it.
     ///
     /// Implementations are allowed to return before the operation is
-    /// complete. See (the docs on embedded-hal)[embedded_hal::spi] for details on flushing.
+    /// complete. See [the docs on embedded-hal][embedded_hal::spi] for details on flushing.
     async fn transfer_in_place(&mut self, words: &mut [Word]) -> Result<(), Self::Error>;
 
     /// Wait until all operations have completed and the bus is idle.
     ///
-    /// See (the docs on embedded-hal)[embedded_hal::spi] for information on flushing.
+    /// See [the docs on embedded-hal][embedded_hal::spi] for information on flushing.
     async fn flush(&mut self) -> Result<(), Self::Error>;
 }
 

--- a/embedded-hal-bus/src/i2c/critical_section.rs
+++ b/embedded-hal-bus/src/i2c/critical_section.rs
@@ -4,7 +4,7 @@ use embedded_hal::i2c::{ErrorType, I2c};
 
 /// `critical-section`-based shared bus [`I2c`] implementation.
 ///
-/// Sharing is implemented with a `critical-section` [`Mutex`](critical_section::Mutex). A critical section is taken for
+/// Sharing is implemented with a `critical-section` [`Mutex`]. A critical section is taken for
 /// the entire duration of a transaction. This allows sharing a single bus across multiple threads (interrupt priority levels).
 /// The downside is critical sections typically require globally disabling interrupts, so `CriticalSectionDevice` will likely
 /// negatively impact real-time properties, such as interrupt latency. If you can, prefer using

--- a/embedded-hal-bus/src/i2c/mutex.rs
+++ b/embedded-hal-bus/src/i2c/mutex.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 
 /// `std` `Mutex`-based shared bus [`I2c`] implementation.
 ///
-/// Sharing is implemented with an `std` [`Mutex`](std::sync::Mutex). It allows a single bus across multiple threads,
+/// Sharing is implemented with an `std` [`Mutex`]. It allows a single bus across multiple threads,
 /// with finer-grained locking than [`CriticalSectionDevice`](super::CriticalSectionDevice). The downside is that
 /// it is only available in `std` targets.
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]

--- a/embedded-hal-bus/src/spi/critical_section.rs
+++ b/embedded-hal-bus/src/spi/critical_section.rs
@@ -23,7 +23,7 @@ pub struct CriticalSectionDevice<'a, BUS, CS, D> {
 }
 
 impl<'a, BUS, CS, D> CriticalSectionDevice<'a, BUS, CS, D> {
-    /// Create a new ExclusiveDevice.
+    /// Create a new [`CriticalSectionDevice`].
     #[inline]
     pub fn new(bus: &'a Mutex<RefCell<BUS>>, cs: CS, delay: D) -> Self {
         Self { bus, cs, delay }
@@ -31,12 +31,12 @@ impl<'a, BUS, CS, D> CriticalSectionDevice<'a, BUS, CS, D> {
 }
 
 impl<'a, BUS, CS> CriticalSectionDevice<'a, BUS, CS, super::NoDelay> {
-    /// Create a new CriticalSectionDevice without support for in-transaction delays.
+    /// Create a new [`CriticalSectionDevice`] without support for in-transaction delays.
     ///
     /// # Panics
     ///
     /// The returned device will panic if you try to execute a transaction
-    /// that contains any operations of type `Operation::DelayUs`.
+    /// that contains any operations of type [`Operation::DelayUs`].
     #[inline]
     pub fn new_no_delay(bus: &'a Mutex<RefCell<BUS>>, cs: CS) -> Self {
         Self {

--- a/embedded-hal-bus/src/spi/critical_section.rs
+++ b/embedded-hal-bus/src/spi/critical_section.rs
@@ -8,10 +8,10 @@ use super::DeviceError;
 
 /// `critical-section`-based shared bus [`SpiDevice`] implementation.
 ///
-/// This allows for sharing an [`SpiBus`](embedded_hal::spi::SpiBus), obtaining multiple [`SpiDevice`] instances,
+/// This allows for sharing an [`SpiBus`], obtaining multiple [`SpiDevice`] instances,
 /// each with its own `CS` pin.
 ///
-/// Sharing is implemented with a `critical-section` [`Mutex`](critical_section::Mutex). A critical section is taken for
+/// Sharing is implemented with a `critical-section` [`Mutex`]. A critical section is taken for
 /// the entire duration of a transaction. This allows sharing a single bus across multiple threads (interrupt priority levels).
 /// The downside is critical sections typically require globally disabling interrupts, so `CriticalSectionDevice` will likely
 /// negatively impact real-time properties, such as interrupt latency. If you can, prefer using

--- a/embedded-hal-bus/src/spi/exclusive.rs
+++ b/embedded-hal-bus/src/spi/exclusive.rs
@@ -13,7 +13,7 @@ use super::DeviceError;
 
 /// [`SpiDevice`] implementation with exclusive access to the bus (not shared).
 ///
-/// This is the most straightforward way of obtaining an [`SpiDevice`] from an [`SpiBus`](embedded_hal::spi::SpiBus),
+/// This is the most straightforward way of obtaining an [`SpiDevice`] from an [`SpiBus`],
 /// ideal for when no sharing is required (only one SPI device is present on the bus).
 pub struct ExclusiveDevice<BUS, CS, D> {
     bus: BUS,

--- a/embedded-hal-bus/src/spi/exclusive.rs
+++ b/embedded-hal-bus/src/spi/exclusive.rs
@@ -22,7 +22,7 @@ pub struct ExclusiveDevice<BUS, CS, D> {
 }
 
 impl<BUS, CS, D> ExclusiveDevice<BUS, CS, D> {
-    /// Create a new ExclusiveDevice.
+    /// Create a new [`ExclusiveDevice`].
     #[inline]
     pub fn new(bus: BUS, cs: CS, delay: D) -> Self {
         Self { bus, cs, delay }
@@ -42,7 +42,7 @@ impl<BUS, CS, D> ExclusiveDevice<BUS, CS, D> {
 }
 
 impl<BUS, CS> ExclusiveDevice<BUS, CS, super::NoDelay> {
-    /// Create a new ExclusiveDevice without support for in-transaction delays.
+    /// Create a new [`ExclusiveDevice`] without support for in-transaction delays.
     ///
     /// # Panics
     ///

--- a/embedded-hal-bus/src/spi/mutex.rs
+++ b/embedded-hal-bus/src/spi/mutex.rs
@@ -7,10 +7,10 @@ use super::DeviceError;
 
 /// `std` `Mutex`-based shared bus [`SpiDevice`] implementation.
 ///
-/// This allows for sharing an [`SpiBus`](embedded_hal::spi::SpiBus), obtaining multiple [`SpiDevice`] instances,
+/// This allows for sharing an [`SpiBus`], obtaining multiple [`SpiDevice`] instances,
 /// each with its own `CS` pin.
 ///
-/// Sharing is implemented with a `std` [`Mutex`](std::sync::Mutex). It allows a single bus across multiple threads,
+/// Sharing is implemented with a `std` [`Mutex`]. It allows a single bus across multiple threads,
 /// with finer-grained locking than [`CriticalSectionDevice`](super::CriticalSectionDevice). The downside is
 /// it is only available in `std` targets.
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]

--- a/embedded-hal-bus/src/spi/refcell.rs
+++ b/embedded-hal-bus/src/spi/refcell.rs
@@ -20,7 +20,7 @@ pub struct RefCellDevice<'a, BUS, CS, D> {
 }
 
 impl<'a, BUS, CS, D> RefCellDevice<'a, BUS, CS, D> {
-    /// Create a new RefCellDevice.
+    /// Create a new [`RefCellDevice`].
     #[inline]
     pub fn new(bus: &'a RefCell<BUS>, cs: CS, delay: D) -> Self {
         Self { bus, cs, delay }
@@ -28,7 +28,7 @@ impl<'a, BUS, CS, D> RefCellDevice<'a, BUS, CS, D> {
 }
 
 impl<'a, BUS, CS> RefCellDevice<'a, BUS, CS, super::NoDelay> {
-    /// Create a new RefCellDevice without support for in-transaction delays.
+    /// Create a new [`RefCellDevice`] without support for in-transaction delays.
     ///
     /// # Panics
     ///

--- a/embedded-hal-bus/src/spi/refcell.rs
+++ b/embedded-hal-bus/src/spi/refcell.rs
@@ -7,7 +7,7 @@ use super::DeviceError;
 
 /// `RefCell`-based shared bus [`SpiDevice`] implementation.
 ///
-/// This allows for sharing an [`SpiBus`](embedded_hal::spi::SpiBus), obtaining multiple [`SpiDevice`] instances,
+/// This allows for sharing an [`SpiBus`], obtaining multiple [`SpiDevice`] instances,
 /// each with its own `CS` pin.
 ///
 /// Sharing is implemented with a `RefCell`. This means it has low overhead, but `RefCellDevice` instances are not `Send`,

--- a/embedded-hal-nb/src/lib.rs
+++ b/embedded-hal-nb/src/lib.rs
@@ -57,7 +57,7 @@
 //! [`svd2rust`]: https://crates.io/crates/svd2rust
 //!
 //! Shown below is an implementation of some of the HAL traits for the [`stm32f1xx-hal`] crate. This
-//! single implementation will work for *any* microcontroller in the STM32F1xx family.
+//! single implementation will work for *any* microcontroller in the `STM32F1xx` family.
 //!
 //! [`stm32f1`]: https://crates.io/crates/stm32f1
 //!


### PR DESCRIPTION
* fix a few links according to markdown rules
* remove a few unneeded qualifiers
* fix `CriticalSectionDevice` that was documented as `ExclusiveDevice`
