### PR TITLE
A few clippy lint fixes

### DIFF
--- a/embedded-can/src/id.rs
+++ b/embedded-can/src/id.rs
@@ -15,6 +15,7 @@ impl StandardId {
     ///
     /// This will return `None` if `raw` is out of range of an 11-bit integer (`> 0x7FF`).
     #[inline]
+    #[must_use]
     pub const fn new(raw: u16) -> Option<Self> {
         if raw <= 0x7FF {
             Some(Self(raw))
@@ -28,12 +29,14 @@ impl StandardId {
     /// # Safety
     /// Using this method can create an invalid ID and is thus marked as unsafe.
     #[inline]
+    #[must_use]
     pub const unsafe fn new_unchecked(raw: u16) -> Self {
         Self(raw)
     }
 
     /// Returns this CAN Identifier as a raw 16-bit integer.
     #[inline]
+    #[must_use]
     pub const fn as_raw(&self) -> u16 {
         self.0
     }
@@ -54,6 +57,7 @@ impl ExtendedId {
     ///
     /// This will return `None` if `raw` is out of range of an 29-bit integer (`> 0x1FFF_FFFF`).
     #[inline]
+    #[must_use]
     pub const fn new(raw: u32) -> Option<Self> {
         if raw <= 0x1FFF_FFFF {
             Some(Self(raw))
@@ -67,17 +71,20 @@ impl ExtendedId {
     /// # Safety
     /// Using this method can create an invalid ID and is thus marked as unsafe.
     #[inline]
+    #[must_use]
     pub const unsafe fn new_unchecked(raw: u32) -> Self {
         Self(raw)
     }
 
     /// Returns this CAN Identifier as a raw 32-bit integer.
     #[inline]
+    #[must_use]
     pub const fn as_raw(&self) -> u32 {
         self.0
     }
 
     /// Returns the Base ID part of this extended identifier.
+    #[must_use]
     pub fn standard_id(&self) -> StandardId {
         // ID-28 to ID-18
         StandardId((self.0 >> 18) as u16)

--- a/embedded-hal-async/src/delay.rs
+++ b/embedded-hal-async/src/delay.rs
@@ -17,11 +17,11 @@ where
 {
     #[inline]
     async fn delay_us(&mut self, us: u32) {
-        T::delay_us(self, us).await
+        T::delay_us(self, us).await;
     }
 
     #[inline]
     async fn delay_ms(&mut self, ms: u32) {
-        T::delay_ms(self, ms).await
+        T::delay_ms(self, ms).await;
     }
 }

--- a/embedded-hal/src/delay.rs
+++ b/embedded-hal/src/delay.rs
@@ -22,11 +22,11 @@ where
 {
     #[inline]
     fn delay_us(&mut self, us: u32) {
-        T::delay_us(self, us)
+        T::delay_us(self, us);
     }
 
     #[inline]
     fn delay_ms(&mut self, ms: u32) {
-        T::delay_ms(self, ms)
+        T::delay_ms(self, ms);
     }
 }

--- a/embedded-io-async/src/lib.rs
+++ b/embedded-io-async/src/lib.rs
@@ -58,10 +58,10 @@ pub trait Read: ErrorType {
                 Err(e) => return Err(ReadExactError::Other(e)),
             }
         }
-        if !buf.is_empty() {
-            Err(ReadExactError::UnexpectedEof)
-        } else {
+        if buf.is_empty() {
             Ok(())
+        } else {
+            Err(ReadExactError::UnexpectedEof)
         }
     }
 }
@@ -170,7 +170,7 @@ impl<T: ?Sized + BufRead> BufRead for &mut T {
     }
 
     fn consume(&mut self, amt: usize) {
-        T::consume(self, amt)
+        T::consume(self, amt);
     }
 }
 

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -362,10 +362,10 @@ pub trait Read: ErrorType {
                 Err(e) => return Err(ReadExactError::Other(e)),
             }
         }
-        if !buf.is_empty() {
-            Err(ReadExactError::UnexpectedEof)
-        } else {
+        if buf.is_empty() {
             Ok(())
+        } else {
+            Err(ReadExactError::UnexpectedEof)
         }
     }
 }
@@ -535,7 +535,7 @@ impl<T: ?Sized + BufRead> BufRead for &mut T {
     }
 
     fn consume(&mut self, amt: usize) {
-        T::consume(self, amt)
+        T::consume(self, amt);
     }
 }
 


### PR DESCRIPTION
* added `[must_use]`
* added a few semicolons
* flip the negating if:  `if !expr { ... } else { ... }`