### PR TITLE
Make embedded-io MSRV 1.48.0

### DIFF
--- a/embedded-io/Cargo.toml
+++ b/embedded-io/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "embedded-io"
 version = "0.5.0"
-edition = "2021"
+edition = "2018"
 description = "Embedded IO traits"
 repository = "https://github.com/rust-embedded/embedded-hal"
 readme = "README.md"

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
-#![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, cfg_attr(all(), doc = include_str!("../README.md")))]
+#![cfg_attr(not(docsrs), doc = "build docs with docsrs")]
 
 use core::fmt;
 
@@ -263,7 +264,7 @@ impl From<WriteAllError<std::io::Error>> for std::io::Error {
 
 impl<E: fmt::Debug> fmt::Display for ReadExactError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
+        write!(f, "{:?}", self)
     }
 }
 
@@ -291,7 +292,7 @@ impl<E> From<E> for WriteFmtError<E> {
 
 impl<E: fmt::Debug> fmt::Display for WriteFmtError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
+        write!(f, "{:?}", self)
     }
 }
 
@@ -317,7 +318,7 @@ impl<E> From<E> for WriteAllError<E> {
 
 impl<E: fmt::Debug> fmt::Display for WriteAllError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
Would it be acceptable to make `embedded-io` crate MSRV 1.48.0 (without features) ?
It seems minimal changes are needed.

The reason to propose this is that rust-bitcoin crate is looking for a replacement for core2 crate, but at the moment has this lower MSRV required for dependencies.

Thanks