### PR TITLE
Updating write functions to return length of written bytes

### DIFF
--- a/embedded-io/CHANGELOG.md
+++ b/embedded-io/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- `write_all` and `write_fmt` now return the number of bytes written to.
+- `write_fmt` now returns the number of bytes written to.
 
 ## 0.5.0 - 2023-08-06
 

--- a/embedded-io/CHANGELOG.md
+++ b/embedded-io/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- `write_all` and `write_fmt` now return the number of bytes written to.
+
 ## 0.5.0 - 2023-08-06
 
 - Add `ReadReady`, `WriteReady` traits. They allow peeking whether the I/O handle is ready to read/write, so they allow using the traits in a non-blocking way.

--- a/embedded-io/src/impls/slice_mut.rs
+++ b/embedded-io/src/impls/slice_mut.rs
@@ -29,3 +29,22 @@ impl Write for &mut [u8] {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::Write;
+
+    #[test]
+    fn basic_length() {
+        let mut buf = [0u8; 1024];
+        let len = write!(&mut buf[..], "Hello!").unwrap();
+        assert!(len == "Hello!".as_bytes().len());
+    }
+
+    #[test]
+    fn format_length() {
+        let mut buf = [0u8; 1024];
+        let len = write!(&mut buf[..], "Hello, {}!", "World").unwrap();
+        assert!(len == "Hello, World!".as_bytes().len());
+    }
+}

--- a/embedded-io/src/impls/slice_mut.rs
+++ b/embedded-io/src/impls/slice_mut.rs
@@ -39,6 +39,7 @@ mod test {
         let mut buf = [0u8; 1024];
         let len = write!(&mut buf[..], "Hello!").unwrap();
         assert!(len == "Hello!".as_bytes().len());
+        assert!(core::str::from_utf8(&buf[..len]).unwrap() == "Hello!");
     }
 
     #[test]
@@ -46,5 +47,6 @@ mod test {
         let mut buf = [0u8; 1024];
         let len = write!(&mut buf[..], "Hello, {}!", "World").unwrap();
         assert!(len == "Hello, World!".as_bytes().len());
+        assert!(core::str::from_utf8(&buf[..len]).unwrap() == "Hello, World!");
     }
 }

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -419,7 +419,7 @@ pub trait Write: ErrorType {
     /// If you are using [`WriteReady`] to avoid blocking, you should not use this function.
     /// `WriteReady::write_ready()` returning true only guarantees the first call to `write()` will
     /// not block, so this function may still block in subsequent calls.
-    fn write_all(&mut self, mut buf: &[u8]) -> Result<usize, WriteAllError<Self::Error>> {
+    fn write_all(&mut self, mut buf: &[u8]) -> Result<(), WriteAllError<Self::Error>> {
         while !buf.is_empty() {
             match self.write(buf) {
                 Ok(0) => return Err(WriteAllError::WriteZero),


### PR DESCRIPTION
This PR updates the `embedded_io::Write` trait to return the number of bytes written for the `write_fmt` function. It seems the length was originally omitted out of simplicity/lack of demand.

However, during my usage, I noted that without this, using a byte slice with `write!()` doesn't provide a result to indicate where the written object ends:
```rs
let mut bytes = [0; 1024];
let _should_be_len = write!(&mut bytes[..], "{:?}", MyObjectThatImplsDebug).unwrap();

// At this point, there is no way to know how many bytes in `bytes` were written, so we don't know where the formatting ends.
```