### PR TITLE
Remove feature(impl_trait_projections) from async traits.

### DIFF
--- a/embedded-hal-async/src/digital.rs
+++ b/embedded-hal-async/src/digital.rs
@@ -50,27 +50,27 @@ pub trait Wait: embedded_hal::digital::ErrorType {
 
 impl<T: Wait + ?Sized> Wait for &mut T {
     #[inline]
-    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+    async fn wait_for_high(&mut self) -> Result<(), T::Error> {
         T::wait_for_high(self).await
     }
 
     #[inline]
-    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+    async fn wait_for_low(&mut self) -> Result<(), T::Error> {
         T::wait_for_low(self).await
     }
 
     #[inline]
-    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+    async fn wait_for_rising_edge(&mut self) -> Result<(), T::Error> {
         T::wait_for_rising_edge(self).await
     }
 
     #[inline]
-    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+    async fn wait_for_falling_edge(&mut self) -> Result<(), T::Error> {
         T::wait_for_falling_edge(self).await
     }
 
     #[inline]
-    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+    async fn wait_for_any_edge(&mut self) -> Result<(), T::Error> {
         T::wait_for_any_edge(self).await
     }
 }

--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -127,12 +127,12 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
 
 impl<A: AddressMode, T: I2c<A> + ?Sized> I2c<A> for &mut T {
     #[inline]
-    async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
+    async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), T::Error> {
         T::read(self, address, read).await
     }
 
     #[inline]
-    async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error> {
+    async fn write(&mut self, address: A, write: &[u8]) -> Result<(), T::Error> {
         T::write(self, address, write).await
     }
 
@@ -142,7 +142,7 @@ impl<A: AddressMode, T: I2c<A> + ?Sized> I2c<A> for &mut T {
         address: A,
         write: &[u8],
         read: &mut [u8],
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), T::Error> {
         T::write_read(self, address, write, read).await
     }
 
@@ -151,7 +151,7 @@ impl<A: AddressMode, T: I2c<A> + ?Sized> I2c<A> for &mut T {
         &mut self,
         address: A,
         operations: &mut [Operation<'_>],
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), T::Error> {
         T::transaction(self, address, operations).await
     }
 }

--- a/embedded-hal-async/src/lib.rs
+++ b/embedded-hal-async/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 #![no_std]
-#![feature(async_fn_in_trait, impl_trait_projections)]
+#![feature(async_fn_in_trait)]
 
 pub mod delay;
 pub mod digital;

--- a/embedded-hal-async/src/spi.rs
+++ b/embedded-hal-async/src/spi.rs
@@ -79,27 +79,27 @@ impl<Word: Copy + 'static, T: SpiDevice<Word> + ?Sized> SpiDevice<Word> for &mut
     async fn transaction(
         &mut self,
         operations: &mut [Operation<'_, Word>],
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), T::Error> {
         T::transaction(self, operations).await
     }
 
     #[inline]
-    async fn read(&mut self, buf: &mut [Word]) -> Result<(), Self::Error> {
+    async fn read(&mut self, buf: &mut [Word]) -> Result<(), T::Error> {
         T::read(self, buf).await
     }
 
     #[inline]
-    async fn write(&mut self, buf: &[Word]) -> Result<(), Self::Error> {
+    async fn write(&mut self, buf: &[Word]) -> Result<(), T::Error> {
         T::write(self, buf).await
     }
 
     #[inline]
-    async fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error> {
+    async fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), T::Error> {
         T::transfer(self, read, write).await
     }
 
     #[inline]
-    async fn transfer_in_place(&mut self, buf: &mut [Word]) -> Result<(), Self::Error> {
+    async fn transfer_in_place(&mut self, buf: &mut [Word]) -> Result<(), T::Error> {
         T::transfer_in_place(self, buf).await
     }
 }
@@ -154,27 +154,27 @@ pub trait SpiBus<Word: 'static + Copy = u8>: ErrorType {
 
 impl<T: SpiBus<Word> + ?Sized, Word: 'static + Copy> SpiBus<Word> for &mut T {
     #[inline]
-    async fn read(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
+    async fn read(&mut self, words: &mut [Word]) -> Result<(), T::Error> {
         T::read(self, words).await
     }
 
     #[inline]
-    async fn write(&mut self, words: &[Word]) -> Result<(), Self::Error> {
+    async fn write(&mut self, words: &[Word]) -> Result<(), T::Error> {
         T::write(self, words).await
     }
 
     #[inline]
-    async fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), Self::Error> {
+    async fn transfer(&mut self, read: &mut [Word], write: &[Word]) -> Result<(), T::Error> {
         T::transfer(self, read, write).await
     }
 
     #[inline]
-    async fn transfer_in_place(&mut self, words: &mut [Word]) -> Result<(), Self::Error> {
+    async fn transfer_in_place(&mut self, words: &mut [Word]) -> Result<(), T::Error> {
         T::transfer_in_place(self, words).await
     }
 
     #[inline]
-    async fn flush(&mut self) -> Result<(), Self::Error> {
+    async fn flush(&mut self) -> Result<(), T::Error> {
         T::flush(self).await
     }
 }

--- a/embedded-hal-bus/src/lib.rs
+++ b/embedded-hal-bus/src/lib.rs
@@ -2,7 +2,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(feature = "async", feature(async_fn_in_trait, impl_trait_projections))]
+#![cfg_attr(feature = "async", feature(async_fn_in_trait))]
 
 // needed to prevent defmt macros from breaking, since they emit code that does `defmt::blahblah`.
 #[cfg(feature = "defmt-03")]

--- a/embedded-io-adapters/src/lib.rs
+++ b/embedded-io-adapters/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
     any(feature = "tokio-1", feature = "futures-03"),
-    feature(async_fn_in_trait, impl_trait_projections)
+    feature(async_fn_in_trait)
 )]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]

--- a/embedded-io-async/src/impls/slice_mut.rs
+++ b/embedded-io-async/src/impls/slice_mut.rs
@@ -1,5 +1,5 @@
 use crate::Write;
-use core::mem;
+use core::{convert::Infallible, mem};
 
 /// Write is implemented for `&mut [u8]` by copying into the slice, overwriting
 /// its data.
@@ -12,7 +12,7 @@ use core::mem;
 /// kind `ErrorKind::WriteZero`.
 impl Write for &mut [u8] {
     #[inline]
-    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Infallible> {
         let amt = core::cmp::min(buf.len(), self.len());
         let (a, b) = mem::take(self).split_at_mut(amt);
         a.copy_from_slice(&buf[..amt]);

--- a/embedded-io-async/src/impls/slice_ref.rs
+++ b/embedded-io-async/src/impls/slice_ref.rs
@@ -1,3 +1,5 @@
+use core::convert::Infallible;
+
 use crate::{BufRead, Read};
 
 /// Read is implemented for `&[u8]` by copying from the slice.
@@ -6,7 +8,7 @@ use crate::{BufRead, Read};
 /// The slice will be empty when EOF is reached.
 impl Read for &[u8] {
     #[inline]
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Infallible> {
         let amt = core::cmp::min(buf.len(), self.len());
         let (a, b) = self.split_at(amt);
 
@@ -26,7 +28,7 @@ impl Read for &[u8] {
 
 impl BufRead for &[u8] {
     #[inline]
-    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+    async fn fill_buf(&mut self) -> Result<&[u8], Infallible> {
         Ok(*self)
     }
 

--- a/embedded-io-async/src/lib.rs
+++ b/embedded-io-async/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(async_fn_in_trait, impl_trait_projections)]
+#![feature(async_fn_in_trait)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
@@ -159,13 +159,13 @@ pub trait Seek: ErrorType {
 
 impl<T: ?Sized + Read> Read for &mut T {
     #[inline]
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, T::Error> {
         T::read(self, buf).await
     }
 }
 
 impl<T: ?Sized + BufRead> BufRead for &mut T {
-    async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+    async fn fill_buf(&mut self) -> Result<&[u8], T::Error> {
         T::fill_buf(self).await
     }
 
@@ -176,19 +176,19 @@ impl<T: ?Sized + BufRead> BufRead for &mut T {
 
 impl<T: ?Sized + Write> Write for &mut T {
     #[inline]
-    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, T::Error> {
         T::write(self, buf).await
     }
 
     #[inline]
-    async fn flush(&mut self) -> Result<(), Self::Error> {
+    async fn flush(&mut self) -> Result<(), T::Error> {
         T::flush(self).await
     }
 }
 
 impl<T: ?Sized + Seek> Seek for &mut T {
     #[inline]
-    async fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+    async fn seek(&mut self, pos: SeekFrom) -> Result<u64, T::Error> {
         T::seek(self, pos).await
     }
 }


### PR DESCRIPTION
It's possible `async_fn_in_traits` will get stabilized before `impl_trait_projections` (see [zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/187312-wg-async/topic/sync.20meeting.202023-09-07)). 

Trying out whether it's feasible to use `async_fn_in_traits` only. Do not merge yet. Since it makes the code a bit uglier, we should only merge this if indeed `async_fn_in_traits` gets stabilized before `impl_trait_projections`.

EDIT: maybe `impl_trait_projections` does get stabilized before AFIT: https://github.com/rust-lang/rust/pull/115659