### PR TITLE
Clarify write() may only return Ok(0) if data is empty

### DIFF
--- a/embedded-io-adapters/CHANGELOG.md
+++ b/embedded-io-adapters/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Add support for adapting `BufRead` from `futures` and `tokio`.
+- Return an error when a wrapped `std`/`futures`/`tokio` `write()` call returns
+  `Ok(0)` to comply with `embedded_io::Write` requirements.
 
 ## 0.5.0 - 2023-08-06
 

--- a/embedded-io-async/src/lib.rs
+++ b/embedded-io-async/src/lib.rs
@@ -10,7 +10,7 @@ extern crate alloc;
 mod impls;
 
 pub use embedded_io::{
-    Error, ErrorKind, ErrorType, ReadExactError, ReadReady, SeekFrom, WriteAllError, WriteReady,
+    Error, ErrorKind, ErrorType, ReadExactError, ReadReady, SeekFrom, WriteReady,
 };
 
 /// Async reader.
@@ -125,13 +125,13 @@ pub trait Write: ErrorType {
     ///
     /// This function is not side-effect-free on cancel (AKA "cancel-safe"), i.e. if you cancel (drop) a returned
     /// future that hasn't completed yet, some bytes might have already been written.
-    async fn write_all(&mut self, buf: &[u8]) -> Result<(), WriteAllError<Self::Error>> {
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
         let mut buf = buf;
         while !buf.is_empty() {
             match self.write(buf).await {
-                Ok(0) => return Err(WriteAllError::WriteZero),
+                Ok(0) => panic!("write() returned Ok(0)"),
                 Ok(n) => buf = &buf[n..],
-                Err(e) => return Err(WriteAllError::Other(e)),
+                Err(e) => return Err(e),
             }
         }
         Ok(())

--- a/embedded-io/CHANGELOG.md
+++ b/embedded-io/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Prohibit `Write::write` implementations returning `Ok(0)` unless there is no
+  data to write; consequently remove `WriteAllError` and the `WriteAllError`
+  variant of `WriteFmtError`. Update the `&mut [u8]` impl to possibly return
+  a new `SliceWriteError` if the slice is full instead of `Ok(0)`.
+- Add `WriteZero` variant to `ErrorKind` for implementations that previously
+  may have returned `Ok(0)` to indicate no further data could be written.
+- `Write::write_all` now panics if the `write()` implementation returns `Ok(0)`.
+
 ## 0.5.0 - 2023-08-06
 
 - Add `ReadReady`, `WriteReady` traits. They allow peeking whether the I/O handle is ready to read/write, so they allow using the traits in a non-blocking way.

--- a/embedded-io/src/impls/slice_mut.rs
+++ b/embedded-io/src/impls/slice_mut.rs
@@ -1,9 +1,40 @@
-use crate::{ErrorType, Write};
+use crate::{Error, ErrorKind, ErrorType, Write};
 use core::mem;
 
-impl ErrorType for &mut [u8] {
-    type Error = core::convert::Infallible;
+// needed to prevent defmt macros from breaking, since they emit code that does `defmt::blahblah`.
+#[cfg(feature = "defmt-03")]
+use defmt_03 as defmt;
+
+/// Errors that could be returned by `Write` on `&mut [u8]`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum SliceWriteError {
+    /// The target slice was full and so could not receive any new data.
+    Full,
 }
+
+impl Error for SliceWriteError {
+    fn kind(&self) -> ErrorKind {
+        match self {
+            SliceWriteError::Full => ErrorKind::WriteZero,
+        }
+    }
+}
+
+impl ErrorType for &mut [u8] {
+    type Error = SliceWriteError;
+}
+
+impl core::fmt::Display for SliceWriteError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for SliceWriteError {}
 
 /// Write is implemented for `&mut [u8]` by copying into the slice, overwriting
 /// its data.
@@ -12,12 +43,14 @@ impl ErrorType for &mut [u8] {
 /// The slice will be empty when it has been completely overwritten.
 ///
 /// If the number of bytes to be written exceeds the size of the slice, write operations will
-/// return short writes: ultimately, `Ok(0)`; in this situation, `write_all` returns an error of
-/// kind `ErrorKind::WriteZero`.
+/// return short writes: ultimately, a `SliceWriteError::Full`.
 impl Write for &mut [u8] {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         let amt = core::cmp::min(buf.len(), self.len());
+        if !buf.is_empty() && amt == 0 {
+            return Err(SliceWriteError::Full);
+        }
         let (a, b) = mem::take(self).split_at_mut(amt);
         a.copy_from_slice(&buf[..amt]);
         *self = b;


### PR DESCRIPTION
Provisional fix for #501.

I'm not totally sure it makes sense to re-add `WriteZero` to `ErrorKind` since we're now using it for something a bit different to `std`, but since we do ask implementations to return an error instead of `Ok(0)`, I guess that error should have a type.