### PR TITLE
Release embedded-io{,-async,-adapters} v0.6.0

### DIFF
--- a/embedded-hal-async/src/lib.rs
+++ b/embedded-hal-async/src/lib.rs
@@ -1,6 +1,11 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 #![no_std]
+// disable warning for already-stabilized features.
+// Needed to pass CI, because we deny warnings.
+// We don't immediately remove them to not immediately break older nightlies.
+// When all features are stable, we'll remove them.
+#![allow(stable_features)]
 #![feature(async_fn_in_trait, impl_trait_projections)]
 
 pub mod delay;

--- a/embedded-hal-bus/src/lib.rs
+++ b/embedded-hal-bus/src/lib.rs
@@ -2,6 +2,11 @@
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// disable warning for already-stabilized features.
+// Needed to pass CI, because we deny warnings.
+// We don't immediately remove them to not immediately break older nightlies.
+// When all features are stable, we'll remove them.
+#![cfg_attr(feature = "async", allow(stable_features))]
 #![cfg_attr(feature = "async", feature(async_fn_in_trait, impl_trait_projections))]
 
 // needed to prevent defmt macros from breaking, since they emit code that does `defmt::blahblah`.

--- a/embedded-io-adapters/CHANGELOG.md
+++ b/embedded-io-adapters/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+Add unreleased changes here
+
+## 0.6.0 - 2023-10-02
+
 - Add support for adapting `BufRead` from `futures` and `tokio`.
 - Return an error when a wrapped `std`/`futures`/`tokio` `write()` call returns
   `Ok(0)` to comply with `embedded_io::Write` requirements.

--- a/embedded-io-adapters/Cargo.toml
+++ b/embedded-io-adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-io-adapters"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Adapters between the `embedded-io` traits and other I/O traits"
 repository = "https://github.com/rust-embedded/embedded-hal"
@@ -17,8 +17,8 @@ tokio-1 = ["std", "dep:tokio", "dep:embedded-io-async", "embedded-io-async?/std"
 futures-03 = ["std", "dep:futures", "dep:embedded-io-async", "embedded-io-async?/std"]
 
 [dependencies]
-embedded-io = { version = "0.5", path = "../embedded-io" }
-embedded-io-async = { version = "0.5", path = "../embedded-io-async", optional = true }
+embedded-io = { version = "0.6", path = "../embedded-io" }
+embedded-io-async = { version = "0.6", path = "../embedded-io-async", optional = true }
 
 futures = { version = "0.3.21", features = ["std"], default-features = false, optional = true }
 tokio = { version = "1", features = ["io-util"], default-features = false, optional = true }

--- a/embedded-io-adapters/src/lib.rs
+++ b/embedded-io-adapters/src/lib.rs
@@ -1,11 +1,19 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
+// disable warning for already-stabilized features.
+// Needed to pass CI, because we deny warnings.
+// We don't immediately remove them to not immediately break older nightlies.
+// When all features are stable, we'll remove them.
+#![cfg_attr(
+    any(feature = "tokio-1", feature = "futures-03"),
+    allow(stable_features)
+)]
 #![cfg_attr(
     any(feature = "tokio-1", feature = "futures-03"),
     feature(async_fn_in_trait, impl_trait_projections)
 )]
-#![warn(missing_docs)]
-#![doc = include_str!("../README.md")]
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]

--- a/embedded-io-async/CHANGELOG.md
+++ b/embedded-io-async/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+Add unreleased changes here
+
+## 0.6.0 - 2023-10-02
+
+- Prohibit `Write::write` implementations returning `Ok(0)` unless there is no
+  data to write; consequently remove `WriteAllError`.
+  Update the `&mut [u8]` impl to possibly return
+  a new `SliceWriteError` if the slice is full instead of `Ok(0)`.
+- Add `WriteZero` variant to `ErrorKind` for implementations that previously
+  may have returned `Ok(0)` to indicate no further data could be written.
+- `Write::write_all` now panics if the `write()` implementation returns `Ok(0)`.
+
 ## 0.5.0 - 2023-08-06
 
 - First release

--- a/embedded-io-async/Cargo.toml
+++ b/embedded-io-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-io-async"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Async embedded IO traits"
 repository = "https://github.com/rust-embedded/embedded-hal"
@@ -17,7 +17,7 @@ alloc = ["embedded-io/alloc"]
 defmt-03 = ["dep:defmt-03", "embedded-io/defmt-03"]
 
 [dependencies]
-embedded-io = { version = "0.5", path = "../embedded-io" }
+embedded-io = { version = "0.6", path = "../embedded-io" }
 defmt-03 = { package = "defmt", version = "0.3", optional = true }
 
 [package.metadata.docs.rs]

--- a/embedded-io-async/src/lib.rs
+++ b/embedded-io-async/src/lib.rs
@@ -1,8 +1,13 @@
-#![feature(async_fn_in_trait, impl_trait_projections)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+// disable warning for already-stabilized features.
+// Needed to pass CI, because we deny warnings.
+// We don't immediately remove them to not immediately break older nightlies.
+// When all features are stable, we'll remove them.
+#![allow(stable_features)]
+#![feature(async_fn_in_trait, impl_trait_projections)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/embedded-io/CHANGELOG.md
+++ b/embedded-io/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.6.0 - 2023-10-02
 
 - Prohibit `Write::write` implementations returning `Ok(0)` unless there is no
   data to write; consequently remove `WriteAllError` and the `WriteAllError`

--- a/embedded-io/Cargo.toml
+++ b/embedded-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-io"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Embedded IO traits"
 repository = "https://github.com/rust-embedded/embedded-hal"


### PR DESCRIPTION
closes #510