### PR TITLE
Make `SliceWriteError` publicly accessible

### DIFF
--- a/embedded-io/src/impls/slice_mut.rs
+++ b/embedded-io/src/impls/slice_mut.rs
@@ -1,18 +1,5 @@
-use crate::{Error, ErrorKind, ErrorType, Write};
+use crate::{Error, ErrorKind, ErrorType, SliceWriteError, Write};
 use core::mem;
-
-// needed to prevent defmt macros from breaking, since they emit code that does `defmt::blahblah`.
-#[cfg(feature = "defmt-03")]
-use defmt_03 as defmt;
-
-/// Errors that could be returned by `Write` on `&mut [u8]`.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
-#[non_exhaustive]
-pub enum SliceWriteError {
-    /// The target slice was full and so could not receive any new data.
-    Full,
-}
 
 impl Error for SliceWriteError {
     fn kind(&self) -> ErrorKind {

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -259,6 +259,15 @@ impl<E: fmt::Debug> fmt::Display for ReadExactError<E> {
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<E: fmt::Debug> std::error::Error for ReadExactError<E> {}
 
+/// Errors that could be returned by `Write` on `&mut [u8]`.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum SliceWriteError {
+    /// The target slice was full and so could not receive any new data.
+    Full,
+}
+
 /// Error returned by [`Write::write_fmt`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]


### PR DESCRIPTION
Closes #512 

I guess we also need to cut a release of some kind, and possibly yank 0.6?