### PR TITLE
Add asynchronous trait for CAN

### DIFF
--- a/embedded-can/Cargo.toml
+++ b/embedded-can/Cargo.toml
@@ -13,3 +13,6 @@ repository = "https://github.com/rust-embedded/embedded-hal"
 
 [dependencies]
 nb = "1"
+
+[features]
+async = []

--- a/embedded-can/src/asynchronous.rs
+++ b/embedded-can/src/asynchronous.rs
@@ -1,0 +1,19 @@
+//! Async CAN API
+
+#![allow(async_fn_in_trait)]
+
+/// An async CAN interface that is able to transmit and receive frames.
+pub trait Can {
+    /// Associated frame type.
+    type Frame: crate::Frame;
+
+    /// Associated error type.
+    type Error: crate::Error;
+
+    /// Puts a frame in the transmit buffer. Waits until space is available in
+    /// the transmit buffer.
+    async fn transmit(&mut self, frame: &Self::Frame) -> Result<(), Self::Error>;
+
+    /// Waits until a frame was received or an error occurred.
+    async fn receive(&mut self) -> Result<Self::Frame, Self::Error>;
+}

--- a/embedded-can/src/lib.rs
+++ b/embedded-can/src/lib.rs
@@ -3,6 +3,8 @@
 #![warn(missing_docs)]
 #![no_std]
 
+#[cfg(feature = "async")]
+pub mod asynchronous;
 pub mod blocking;
 pub mod nb;
 


### PR DESCRIPTION
Async fn in trait is stabilized in nightly 1.75, which means folks can opt in to async when using nightly, but can continue to use blocking and nb without it.

fixes: #468

I'm bad at names. I don't know if there is a better convention to have an async mod alongside `nb` and `blocking`.

I've implemented these signatures in my esp32-c3 driver's inherent implementation and is working wonderfully. I would love to have this be supported by embedded-hal, so I can make the CANOpen implementation I am working on generic over the async trait and to share.