### PR TITLE
Make Cargo feature explicit

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -14,4 +14,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2023-10-14
-      - run: RUSTDOCFLAGS="--deny=warnings --cfg=docsrs" cargo doc --all-features
+      # tokio/net required to workaround https://github.com/tokio-rs/tokio/issues/6165
+      - run: RUSTDOCFLAGS="--deny=warnings --cfg=docsrs" cargo doc --all-features --features tokio/net

--- a/embedded-hal/Cargo.toml
+++ b/embedded-hal/Cargo.toml
@@ -15,5 +15,8 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
 version = "1.0.0-rc.1"
 
+[features]
+defmt-03 = ["dep:defmt-03"]
+
 [dependencies]
 defmt-03 = { package = "defmt", version = "0.3", optional = true }


### PR DESCRIPTION
To keep consistent with all other crates, and for clarity, it is best to explicitly declare `defmt-03` as a feature of the `embedded-hal` crate. This way people can look at the `[features]` section rather than search through any optional dependencies.  In this case it's not that big of a deal, but it keeps the pattern.