### PR TITLE
pwm: rename `get_max_duty_cycle` to `max_duty_cycle`.

### DIFF
--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Minor document fixes.
 - Add #[inline] hints to most of `embedded-hal` functions.
+- pwm: rename `get_max_duty_cycle` to `max_duty_cycle`.
 
 ## [v1.0.0-rc.1] - 2023-08-15
 

--- a/embedded-hal/src/pwm.rs
+++ b/embedded-hal/src/pwm.rs
@@ -69,7 +69,7 @@ pub trait SetDutyCycle: ErrorType {
     /// Get the maximum duty cycle value.
     ///
     /// This value corresponds to a 100% duty cycle.
-    fn get_max_duty_cycle(&self) -> u16;
+    fn max_duty_cycle(&self) -> u16;
 
     /// Set the duty cycle to `duty / max_duty`.
     ///
@@ -86,7 +86,7 @@ pub trait SetDutyCycle: ErrorType {
     /// Set the duty cycle to 100%, or always active.
     #[inline]
     fn set_duty_cycle_fully_on(&mut self) -> Result<(), Self::Error> {
-        self.set_duty_cycle(self.get_max_duty_cycle())
+        self.set_duty_cycle(self.max_duty_cycle())
     }
 
     /// Set the duty cycle to `num / denom`.
@@ -97,9 +97,9 @@ pub trait SetDutyCycle: ErrorType {
     fn set_duty_cycle_fraction(&mut self, num: u16, denom: u16) -> Result<(), Self::Error> {
         debug_assert!(denom != 0);
         debug_assert!(num <= denom);
-        let duty = u32::from(num) * u32::from(self.get_max_duty_cycle()) / u32::from(denom);
+        let duty = u32::from(num) * u32::from(self.max_duty_cycle()) / u32::from(denom);
 
-        // This is safe because we know that `num <= denom`, so `duty <= self.get_max_duty_cycle()` (u16)
+        // This is safe because we know that `num <= denom`, so `duty <= self.max_duty_cycle()` (u16)
         #[allow(clippy::cast_possible_truncation)]
         {
             self.set_duty_cycle(duty as u16)
@@ -117,8 +117,8 @@ pub trait SetDutyCycle: ErrorType {
 
 impl<T: SetDutyCycle + ?Sized> SetDutyCycle for &mut T {
     #[inline]
-    fn get_max_duty_cycle(&self) -> u16 {
-        T::get_max_duty_cycle(self)
+    fn max_duty_cycle(&self) -> u16 {
+        T::max_duty_cycle(self)
     }
 
     #[inline]


### PR DESCRIPTION
fixes #524