### PR TITLE
Rename `DelayUs` to `BasicDelay`, add `delay_ns`.

### DIFF
--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - delay: Rename `DelayUs` to `DelayNs`
 - delay: Add `DelayNs::delay_ns()`
 - delay: Add default impls of `delay_ms` and `delay_us` based on `delay_ns`.
+- spi: Rename `Operation::DelayUs` to `Operation::DelayNs`, with nanosecond precision.
 
 ## [v1.0.0-rc.1] - 2023-08-15
 

--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Minor document fixes.
 - Add #[inline] hints to most of `embedded-hal-async` functions.
+- delay: Rename `DelayUs` to `DelayNs`
+- delay: Add `DelayNs::delay_ns()`
+- delay: Add default impls of `delay_ms` and `delay_us` based on `delay_ns`.
 
 ## [v1.0.0-rc.1] - 2023-08-15
 

--- a/embedded-hal-async/src/delay.rs
+++ b/embedded-hal-async/src/delay.rs
@@ -1,20 +1,42 @@
 //! Delays.
 
-/// Microsecond delay.
-pub trait DelayUs {
+/// Delay with up to nanosecond precision.
+pub trait DelayNs {
+    /// Pauses execution for at minimum `ns` nanoseconds. Pause can be longer
+    /// if the implementation requires it due to precision/timing issues.
+    async fn delay_ns(&mut self, ns: u32);
+
     /// Pauses execution for at minimum `us` microseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
-    async fn delay_us(&mut self, us: u32);
+    async fn delay_us(&mut self, mut us: u32) {
+        while us > 4_294_967 {
+            us -= 4_294_967;
+            self.delay_ns(4_294_967_000).await;
+        }
+        self.delay_ns(us * 1_000).await;
+    }
 
     /// Pauses execution for at minimum `ms` milliseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
-    async fn delay_ms(&mut self, ms: u32);
+    #[inline]
+    async fn delay_ms(&mut self, mut ms: u32) {
+        while ms > 4294 {
+            ms -= 4294;
+            self.delay_ns(4_294_000_000).await;
+        }
+        self.delay_ns(ms * 1_000_000).await;
+    }
 }
 
-impl<T> DelayUs for &mut T
+impl<T> DelayNs for &mut T
 where
-    T: DelayUs + ?Sized,
+    T: DelayNs + ?Sized,
 {
+    #[inline]
+    async fn delay_ns(&mut self, ns: u32) {
+        T::delay_ns(self, ns).await;
+    }
+
     #[inline]
     async fn delay_us(&mut self, us: u32) {
         T::delay_us(self, us).await;

--- a/embedded-hal-bus/src/spi/critical_section.rs
+++ b/embedded-hal-bus/src/spi/critical_section.rs
@@ -37,7 +37,7 @@ impl<'a, BUS, CS> CriticalSectionDevice<'a, BUS, CS, super::NoDelay> {
     /// # Panics
     ///
     /// The returned device will panic if you try to execute a transaction
-    /// that contains any operations of type [`Operation::DelayUs`].
+    /// that contains any operations of type [`Operation::DelayNs`].
     #[inline]
     pub fn new_no_delay(bus: &'a Mutex<RefCell<BUS>>, cs: CS) -> Self {
         Self {

--- a/embedded-hal-bus/src/spi/critical_section.rs
+++ b/embedded-hal-bus/src/spi/critical_section.rs
@@ -1,6 +1,6 @@
 use core::cell::RefCell;
 use critical_section::Mutex;
-use embedded_hal::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 
@@ -60,7 +60,7 @@ impl<'a, Word: Copy + 'static, BUS, CS, D> SpiDevice<Word> for CriticalSectionDe
 where
     BUS: SpiBus<Word>,
     CS: OutputPin,
-    D: DelayUs,
+    D: DelayNs,
 {
     #[inline]
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {

--- a/embedded-hal-bus/src/spi/exclusive.rs
+++ b/embedded-hal-bus/src/spi/exclusive.rs
@@ -5,10 +5,11 @@ use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 #[cfg(feature = "async")]
 use embedded_hal_async::{
-    delay::DelayNs as AsyncDelayUs,
+    delay::DelayNs as AsyncDelayNs,
     spi::{SpiBus as AsyncSpiBus, SpiDevice as AsyncSpiDevice},
 };
 
+use super::shared::transaction;
 use super::DeviceError;
 
 /// [`SpiDevice`] implementation with exclusive access to the bus (not shared).
@@ -47,7 +48,7 @@ impl<BUS, CS> ExclusiveDevice<BUS, CS, super::NoDelay> {
     /// # Panics
     ///
     /// The returned device will panic if you try to execute a transaction
-    /// that contains any operations of type `Operation::DelayUs`.
+    /// that contains any operations of type [`Operation::DelayNs`].
     #[inline]
     pub fn new_no_delay(bus: BUS, cs: CS) -> Self {
         Self {
@@ -84,7 +85,7 @@ impl<Word: Copy + 'static, BUS, CS, D> AsyncSpiDevice<Word> for ExclusiveDevice<
 where
     BUS: AsyncSpiBus<Word>,
     CS: OutputPin,
-    D: AsyncDelayUs,
+    D: AsyncDelayNs,
 {
     #[inline]
     async fn transaction(
@@ -100,10 +101,10 @@ where
                     Operation::Write(buf) => self.bus.write(buf).await,
                     Operation::Transfer(read, write) => self.bus.transfer(read, write).await,
                     Operation::TransferInPlace(buf) => self.bus.transfer_in_place(buf).await,
-                    Operation::DelayUs(us) => match self.bus.flush().await {
+                    Operation::DelayNs(ns) => match self.bus.flush().await {
                         Err(e) => Err(e),
                         Ok(()) => {
-                            self.delay.delay_us(*us).await;
+                            self.delay.delay_ns(*ns).await;
                             Ok(())
                         }
                     },

--- a/embedded-hal-bus/src/spi/exclusive.rs
+++ b/embedded-hal-bus/src/spi/exclusive.rs
@@ -1,11 +1,11 @@
 //! SPI bus sharing mechanisms.
 
-use embedded_hal::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 #[cfg(feature = "async")]
 use embedded_hal_async::{
-    delay::DelayUs as AsyncDelayUs,
+    delay::DelayNs as AsyncDelayUs,
     spi::{SpiBus as AsyncSpiBus, SpiDevice as AsyncSpiDevice},
 };
 
@@ -70,7 +70,7 @@ impl<Word: Copy + 'static, BUS, CS, D> SpiDevice<Word> for ExclusiveDevice<BUS, 
 where
     BUS: SpiBus<Word>,
     CS: OutputPin,
-    D: DelayUs,
+    D: DelayNs,
 {
     #[inline]
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {

--- a/embedded-hal-bus/src/spi/mod.rs
+++ b/embedded-hal-bus/src/spi/mod.rs
@@ -43,14 +43,14 @@ where
     }
 }
 
-/// Dummy `DelayUs` implementation that panics on use.
+/// Dummy [`DelayNs`](embedded_hal::delay::DelayNs) implementation that panics on use.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct NoDelay;
 
 #[cold]
 fn no_delay_panic() {
-    panic!("You've tried to execute a SPI transaction containing a `Operation::Delay` in a `SpiDevice` created with `new_no_delay()`. Create it with `new()` instead, passing a `DelayUs` implementation.");
+    panic!("You've tried to execute a SPI transaction containing a `Operation::DelayNs` in a `SpiDevice` created with `new_no_delay()`. Create it with `new()` instead, passing a `DelayNs` implementation.");
 }
 
 impl embedded_hal::delay::DelayNs for NoDelay {

--- a/embedded-hal-bus/src/spi/mod.rs
+++ b/embedded-hal-bus/src/spi/mod.rs
@@ -53,23 +53,18 @@ fn no_delay_panic() {
     panic!("You've tried to execute a SPI transaction containing a `Operation::Delay` in a `SpiDevice` created with `new_no_delay()`. Create it with `new()` instead, passing a `DelayUs` implementation.");
 }
 
-impl embedded_hal::delay::DelayUs for NoDelay {
+impl embedded_hal::delay::DelayNs for NoDelay {
     #[inline]
-    fn delay_us(&mut self, _us: u32) {
+    fn delay_ns(&mut self, _ns: u32) {
         no_delay_panic();
     }
 }
 
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-impl embedded_hal_async::delay::DelayUs for NoDelay {
+impl embedded_hal_async::delay::DelayNs for NoDelay {
     #[inline]
-    async fn delay_us(&mut self, _us: u32) {
-        no_delay_panic();
-    }
-
-    #[inline]
-    async fn delay_ms(&mut self, _ms: u32) {
+    async fn delay_ns(&mut self, _ns: u32) {
         no_delay_panic();
     }
 }

--- a/embedded-hal-bus/src/spi/mutex.rs
+++ b/embedded-hal-bus/src/spi/mutex.rs
@@ -1,4 +1,4 @@
-use embedded_hal::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 use std::sync::Mutex;
@@ -58,7 +58,7 @@ impl<'a, Word: Copy + 'static, BUS, CS, D> SpiDevice<Word> for MutexDevice<'a, B
 where
     BUS: SpiBus<Word>,
     CS: OutputPin,
-    D: DelayUs,
+    D: DelayNs,
 {
     #[inline]
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {

--- a/embedded-hal-bus/src/spi/mutex.rs
+++ b/embedded-hal-bus/src/spi/mutex.rs
@@ -35,7 +35,7 @@ impl<'a, BUS, CS> MutexDevice<'a, BUS, CS, super::NoDelay> {
     /// # Panics
     ///
     /// The returned device will panic if you try to execute a transaction
-    /// that contains any operations of type `Operation::DelayUs`.
+    /// that contains any operations of type [`Operation::DelayNs`].
     #[inline]
     pub fn new_no_delay(bus: &'a Mutex<BUS>, cs: CS) -> Self {
         Self {

--- a/embedded-hal-bus/src/spi/refcell.rs
+++ b/embedded-hal-bus/src/spi/refcell.rs
@@ -1,5 +1,5 @@
 use core::cell::RefCell;
-use embedded_hal::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 
@@ -57,7 +57,7 @@ impl<'a, Word: Copy + 'static, BUS, CS, D> SpiDevice<Word> for RefCellDevice<'a,
 where
     BUS: SpiBus<Word>,
     CS: OutputPin,
-    D: DelayUs,
+    D: DelayNs,
 {
     #[inline]
     fn transaction(&mut self, operations: &mut [Operation<'_, Word>]) -> Result<(), Self::Error> {

--- a/embedded-hal-bus/src/spi/refcell.rs
+++ b/embedded-hal-bus/src/spi/refcell.rs
@@ -34,7 +34,7 @@ impl<'a, BUS, CS> RefCellDevice<'a, BUS, CS, super::NoDelay> {
     /// # Panics
     ///
     /// The returned device will panic if you try to execute a transaction
-    /// that contains any operations of type `Operation::DelayUs`.
+    /// that contains any operations of type [`Operation::DelayNs`].
     #[inline]
     pub fn new_no_delay(bus: &'a RefCell<BUS>, cs: CS) -> Self {
         Self {

--- a/embedded-hal-bus/src/spi/shared.rs
+++ b/embedded-hal-bus/src/spi/shared.rs
@@ -25,9 +25,9 @@ where
         Operation::Write(buf) => bus.write(buf),
         Operation::Transfer(read, write) => bus.transfer(read, write),
         Operation::TransferInPlace(buf) => bus.transfer_in_place(buf),
-        Operation::DelayUs(us) => {
+        Operation::DelayNs(ns) => {
             bus.flush()?;
-            delay.delay_us(*us);
+            delay.delay_ns(*ns);
             Ok(())
         }
     });

--- a/embedded-hal-bus/src/spi/shared.rs
+++ b/embedded-hal-bus/src/spi/shared.rs
@@ -1,4 +1,4 @@
-use embedded_hal::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus};
 
@@ -15,7 +15,7 @@ pub fn transaction<Word, BUS, CS, D>(
 where
     BUS: SpiBus<Word> + ErrorType,
     CS: OutputPin,
-    D: DelayUs,
+    D: DelayNs,
     Word: Copy,
 {
     cs.set_low().map_err(DeviceError::Cs)?;

--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - delay: Add `DelayNs::delay_ns()`
 - delay: Add default impls of `delay_ms` and `delay_us` based on `delay_ns`.
 - delay: Make the default impl of `delay_ms` more efficient, it now does less calls to the underlying `delay_ns` (previously `delay_us`).
+- spi: Rename `Operation::DelayUs` to `Operation::DelayNs`, with nanosecond precision.
 
 ## [v1.0.0-rc.1] - 2023-08-15
 

--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Minor document fixes.
 - Add #[inline] hints to most of `embedded-hal` functions.
 - pwm: rename `get_max_duty_cycle` to `max_duty_cycle`.
+- delay: Rename `DelayUs` to `DelayNs`
+- delay: Add `DelayNs::delay_ns()`
+- delay: Add default impls of `delay_ms` and `delay_us` based on `delay_ns`.
+- delay: Make the default impl of `delay_ms` more efficient, it now does less calls to the underlying `delay_ns` (previously `delay_us`).
 
 ## [v1.0.0-rc.1] - 2023-08-15
 

--- a/embedded-hal/src/delay.rs
+++ b/embedded-hal/src/delay.rs
@@ -1,25 +1,42 @@
 //! Delays.
 
-/// Microsecond delay.
-pub trait DelayUs {
+/// Delay with up to nanosecond precision.
+pub trait DelayNs {
+    /// Pauses execution for at minimum `ns` nanoseconds. Pause can be longer
+    /// if the implementation requires it due to precision/timing issues.
+    fn delay_ns(&mut self, ns: u32);
+
     /// Pauses execution for at minimum `us` microseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
-    fn delay_us(&mut self, us: u32);
+    fn delay_us(&mut self, mut us: u32) {
+        while us > 4_294_967 {
+            us -= 4_294_967;
+            self.delay_ns(4_294_967_000);
+        }
+        self.delay_ns(us * 1_000);
+    }
 
     /// Pauses execution for at minimum `ms` milliseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
     #[inline]
-    fn delay_ms(&mut self, ms: u32) {
-        for _ in 0..ms {
-            self.delay_us(1000);
+    fn delay_ms(&mut self, mut ms: u32) {
+        while ms > 4294 {
+            ms -= 4294;
+            self.delay_ns(4_294_000_000);
         }
+        self.delay_ns(ms * 1_000_000);
     }
 }
 
-impl<T> DelayUs for &mut T
+impl<T> DelayNs for &mut T
 where
-    T: DelayUs + ?Sized,
+    T: DelayNs + ?Sized,
 {
+    #[inline]
+    fn delay_ns(&mut self, ns: u32) {
+        T::delay_ns(self, ns);
+    }
+
     #[inline]
     fn delay_us(&mut self, us: u32) {
         T::delay_us(self, us);

--- a/embedded-hal/src/spi.rs
+++ b/embedded-hal/src/spi.rs
@@ -324,8 +324,8 @@ pub enum Operation<'a, Word: 'static> {
     ///
     /// Equivalent to [`SpiBus::transfer_in_place`].
     TransferInPlace(&'a mut [Word]),
-    /// Delay for at least the specified number of microseconds.
-    DelayUs(u32),
+    /// Delay for at least the specified number of nanoseconds.
+    DelayNs(u32),
 }
 
 /// SPI device trait.


### PR DESCRIPTION
As discussed in today's meeting, we should add nanosecond precision to the delay trait.

Fixes #521
Fixes #535

Though as discussed in the meeting as well, we should add configuration settings to the SpiDevice impls in `embedded-hal-bus` to do the delays, and document drivers are discouraged from using `Operation::DelayNs` for CS-to-clocks delays. Opened #537 to track this