### PR TITLE
Use named constants to clarify delay-stepdown behavior

### DIFF
--- a/embedded-hal/src/delay.rs
+++ b/embedded-hal/src/delay.rs
@@ -16,7 +16,7 @@ pub trait DelayNs {
     fn delay_us(&mut self, mut us: u32) {
         const MAX_MICROS: u32 = u32::MAX / NANOS_PER_MICRO;
 
-        // Avoid potential overflow if micro -> micro conversion is too large
+        // Avoid potential overflow if micro -> nano conversion is too large
         while us > MAX_MICROS {
             us -= MAX_MICROS;
             self.delay_ns(MAX_MICROS * NANOS_PER_MICRO);
@@ -31,7 +31,7 @@ pub trait DelayNs {
     fn delay_ms(&mut self, mut ms: u32) {
         const MAX_MILLIS: u32 = u32::MAX / NANOS_PER_MILLI;
 
-        // Avoid potential overflow if milli -> micro conversion is too large
+        // Avoid potential overflow if milli -> nano conversion is too large
         while ms > MAX_MILLIS {
             ms -= MAX_MILLIS;
             self.delay_ns(MAX_MILLIS * NANOS_PER_MILLI);

--- a/embedded-hal/src/delay.rs
+++ b/embedded-hal/src/delay.rs
@@ -1,5 +1,10 @@
 //! Delays.
 
+/// Nanoseconds per microsecond
+const NANOS_PER_MICRO: u32 = 1_000;
+/// Nanoseconds per millisecond
+const NANOS_PER_MILLI: u32 = 1_000_000;
+
 /// Delay with up to nanosecond precision.
 pub trait DelayNs {
     /// Pauses execution for at minimum `ns` nanoseconds. Pause can be longer
@@ -9,22 +14,30 @@ pub trait DelayNs {
     /// Pauses execution for at minimum `us` microseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
     fn delay_us(&mut self, mut us: u32) {
-        while us > 4_294_967 {
-            us -= 4_294_967;
-            self.delay_ns(4_294_967_000);
+        const MAX_MICROS: u32 = u32::MAX / NANOS_PER_MICRO;
+
+        // Avoid potential overflow if micro -> micro conversion is too large
+        while us > MAX_MICROS {
+            us -= MAX_MICROS;
+            self.delay_ns(MAX_MICROS * NANOS_PER_MICRO);
         }
-        self.delay_ns(us * 1_000);
+
+        self.delay_ns(us * NANOS_PER_MICRO);
     }
 
     /// Pauses execution for at minimum `ms` milliseconds. Pause can be longer
     /// if the implementation requires it due to precision/timing issues.
     #[inline]
     fn delay_ms(&mut self, mut ms: u32) {
-        while ms > 4294 {
-            ms -= 4294;
-            self.delay_ns(4_294_000_000);
+        const MAX_MILLIS: u32 = u32::MAX / NANOS_PER_MILLI;
+
+        // Avoid potential overflow if milli -> micro conversion is too large
+        while ms > MAX_MILLIS {
+            ms -= MAX_MILLIS;
+            self.delay_ns(MAX_MILLIS * NANOS_PER_MILLI);
         }
-        self.delay_ns(ms * 1_000_000);
+
+        self.delay_ns(ms * NANOS_PER_MILLI);
     }
 }
 


### PR DESCRIPTION
Add some named constants to clarify behavior/intent, which confused at least one person already.

The compiler almost certainly should be able to optimize away `N / M * M`, but if we'd like to be extra sure, I can add another const.