### PR TITLE
gpio: require `&mut self` in `InputPin` and `StatefulOutputPin`.

### DIFF
--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-No unreleased changes
+- gpio: require `&mut self` in `InputPin` and `StatefulOutputPin`.
 
 ## [v1.0.0-rc.2] - 2023-11-28
 

--- a/embedded-hal/src/digital.rs
+++ b/embedded-hal/src/digital.rs
@@ -169,22 +169,22 @@ pub trait StatefulOutputPin: OutputPin {
     /// Is the pin in drive high mode?
     ///
     /// *NOTE* this does *not* read the electrical state of the pin.
-    fn is_set_high(&self) -> Result<bool, Self::Error>;
+    fn is_set_high(&mut self) -> Result<bool, Self::Error>;
 
     /// Is the pin in drive low mode?
     ///
     /// *NOTE* this does *not* read the electrical state of the pin.
-    fn is_set_low(&self) -> Result<bool, Self::Error>;
+    fn is_set_low(&mut self) -> Result<bool, Self::Error>;
 }
 
 impl<T: StatefulOutputPin + ?Sized> StatefulOutputPin for &mut T {
     #[inline]
-    fn is_set_high(&self) -> Result<bool, Self::Error> {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
         T::is_set_high(self)
     }
 
     #[inline]
-    fn is_set_low(&self) -> Result<bool, Self::Error> {
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
         T::is_set_low(self)
     }
 }
@@ -205,20 +205,20 @@ impl<T: ToggleableOutputPin + ?Sized> ToggleableOutputPin for &mut T {
 /// Single digital input pin.
 pub trait InputPin: ErrorType {
     /// Is the input pin high?
-    fn is_high(&self) -> Result<bool, Self::Error>;
+    fn is_high(&mut self) -> Result<bool, Self::Error>;
 
     /// Is the input pin low?
-    fn is_low(&self) -> Result<bool, Self::Error>;
+    fn is_low(&mut self) -> Result<bool, Self::Error>;
 }
 
-impl<T: InputPin + ?Sized> InputPin for &T {
+impl<T: InputPin + ?Sized> InputPin for &mut T {
     #[inline]
-    fn is_high(&self) -> Result<bool, Self::Error> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
         T::is_high(self)
     }
 
     #[inline]
-    fn is_low(&self) -> Result<bool, Self::Error> {
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
         T::is_low(self)
     }
 }


### PR DESCRIPTION

InputPin should require `&mut self` just like the other traits.

It has required `&self` since forever (#36), but I can't find any discussion on why or the pros and cons. If I had to guess, I'd say the historical answer is probably "inputs are read only, therefore can be shared safely, therefore &".

However, using `&self` rules out implementations that

- have mutable state (like in #546), or
- require exclusive access to something, for example an spi/i2c bus for a gpio expander.

These are disadvantages. However, are there any advantages to requiring only `&self`? I don't think so. The main use of a `&self` InputPin would be a driver that somehow splits itself in "parts" where each part needs access to the same pin. However it's unlikely that the *only* shared thing is an InputPin, it's likely they also need sharing something that requires `&mut`, like an OutputPin, or UART/SPI/I2C. Even with this change, drivers can still share InputPins with `RefCell`s.

Using `&self` forces the trait *implementation* to use a RefCell, which means all uses of it pay the overhead. If we require `&mut`, only drivers that actually need sharing pay the cost of the `RefCell`.

This doesn't hurt usability of HAL-dependent code, HAL crates can still provide a HAL-specific `fn is_high(&self)` method that takes `&self`, just like many offer infallible methods now.

Also, a big reason of making GPIO traits fallible is to support port expanders, but these need `&mut self`. We're doing only "half" the changes to support these, it's a bit incoherent/inconsistent.

Fixes #546 
