### PR TITLE
Misc doc fixes.

### DIFF
--- a/docs/migrating-from-0.2-to-1.0.md
+++ b/docs/migrating-from-0.2-to-1.0.md
@@ -340,7 +340,7 @@ have mutable state or access exclusive resources.
 for implementations.
 
 For ease of use, you might want to provide inherent methods that take `&self` if the hardware permits it. In this case,
-you might need to do `&*self` to call them from the trait methods. Otherwise Rust will resolve the
+you might need to do `*self` to call them from the trait methods. Otherwise Rust will resolve the
 method call to the trait method, causing infinite recursion.
 
 ```rust
@@ -358,12 +358,12 @@ impl HalPin {
 
 impl InputPin for HalPin {
     fn is_high(&mut self) -> Result<bool, Self::Error> {
-        // Needs `&*self` so that the inherent `is_high` is picked.
-        Ok((&*self).is_high())
+        // Needs `*self` so that the inherent `is_high` is picked.
+        Ok((*self).is_high())
     }
     
     fn is_low(&mut self) -> Result<bool, Self::Error> {
-        Ok((&*self).is_low())
+        Ok((*self).is_low())
     }
 }
 ```

--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -11,6 +11,8 @@ No unreleased changes yet.
 
 ## [v1.0.0] - 2023-12-28
 
+Check out the [announcement blog post](https://blog.rust-embedded.org/embedded-hal-v1/) and the [migration guide](../docs/migrating-from-0.2-to-1.0.md) for help with migrating from v0.2 to v1.0.
+
 - Updated `embedded-hal` to version `1.0.0`.
 
 ## [v1.0.0-rc.3] - 2023-12-14

--- a/embedded-hal-nb/CHANGELOG.md
+++ b/embedded-hal-nb/CHANGELOG.md
@@ -11,7 +11,7 @@ No unreleased changes
 
 ## [v1.0.0] - 2023-12-28
 
-CheckCheck out the [announcement blog post](https://blog.rust-embedded.org/embedded-hal-v1/) and the [migration guide](../docs/migrating-from-0.2-to-1.0.md) for help with migrating from v0.2 to v1.0.
+Check out the [announcement blog post](https://blog.rust-embedded.org/embedded-hal-v1/) and the [migration guide](../docs/migrating-from-0.2-to-1.0.md) for help with migrating from v0.2 to v1.0.
 
 - Updated `embedded-hal` to version `1.0.0`.
 

--- a/embedded-hal-nb/CHANGELOG.md
+++ b/embedded-hal-nb/CHANGELOG.md
@@ -11,6 +11,8 @@ No unreleased changes
 
 ## [v1.0.0] - 2023-12-28
 
+CheckCheck out the [announcement blog post](https://blog.rust-embedded.org/embedded-hal-v1/) and the [migration guide](../docs/migrating-from-0.2-to-1.0.md) for help with migrating from v0.2 to v1.0.
+
 - Updated `embedded-hal` to version `1.0.0`.
 
 ## [v1.0.0-rc.3] - 2023-12-14

--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -11,6 +11,8 @@ No unreleased changes yet.
 
 ## [v1.0.0] - 2023-12-28
 
+Check out the [announcement blog post](https://blog.rust-embedded.org/embedded-hal-v1/) and the [migration guide](../docs/migrating-from-0.2-to-1.0.md) for help with migrating from v0.2 to v1.0.
+
 - gpio: remove `ToggleableOutputPin`, move `toggle()` to `StatefulOutputPin`.
 
 ## [v1.0.0-rc.3] - 2023-12-14


### PR DESCRIPTION
- migration: autoderef workaround still works with just `*self`.
- Link to announcement blog post and migration guide in changelogs.
