### PR TITLE
Use shields.io's MSRV badges

### DIFF
--- a/embedded-hal-bus/README.md
+++ b/embedded-hal-bus/README.md
@@ -1,7 +1,7 @@
 [![crates.io](https://img.shields.io/crates/d/embedded-hal-bus.svg)](https://crates.io/crates/embedded-hal-bus)
 [![crates.io](https://img.shields.io/crates/v/embedded-hal-bus.svg)](https://crates.io/crates/embedded-hal-bus)
 [![Documentation](https://docs.rs/embedded-hal-bus/badge.svg)](https://docs.rs/embedded-hal-bus)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.60+-blue.svg)
+![Minimum Supported Rust Version](https://img.shields.io/crates/msrv/embedded-hal-bus.svg)
 
 # `embedded-hal-bus`
 

--- a/embedded-hal-nb/README.md
+++ b/embedded-hal-nb/README.md
@@ -1,7 +1,7 @@
 [![crates.io](https://img.shields.io/crates/d/embedded-hal-nb.svg)](https://crates.io/crates/embedded-hal-nb)
 [![crates.io](https://img.shields.io/crates/v/embedded-hal-nb.svg)](https://crates.io/crates/embedded-hal-nb)
 [![Documentation](https://docs.rs/embedded-hal-nb/badge.svg)](https://docs.rs/embedded-hal-nb)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.60+-blue.svg)
+![Minimum Supported Rust Version](https://img.shields.io/crates/msrv/embedded-hal-nb.svg)
 
 # `embedded-hal-nb`
 

--- a/embedded-hal/README.md
+++ b/embedded-hal/README.md
@@ -1,7 +1,7 @@
 [![crates.io](https://img.shields.io/crates/d/embedded-hal.svg)](https://crates.io/crates/embedded-hal)
 [![crates.io](https://img.shields.io/crates/v/embedded-hal.svg)](https://crates.io/crates/embedded-hal)
 [![Documentation](https://docs.rs/embedded-hal/badge.svg)](https://docs.rs/embedded-hal)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.60+-blue.svg)
+![Minimum Supported Rust Version](https://img.shields.io/crates/msrv/embedded-hal.svg)
 
 # `embedded-hal`
 


### PR DESCRIPTION
Added in https://github.com/badges/shields/pull/9871

Updated:
- `embedded-hal`
- `embedded-hal-bus`
- `embedded-hal-nb`: old badge said 1.60 but rust-version in Cargo.toml is set to 1.56

Skipped:
- `embedded-can`: rust-version field is blank on crates.io

No Badge (MSRV is in readme):
- `embedded-hal-async`
- `embedded-io-adapters`
- `embedded-io-async`
- `embedded-io`

(I can add a badge for these if desired)