### PR TITLE
Re-export `digital` error types in `embedded-hal-async`.

### DIFF
--- a/embedded-hal-async/src/digital.rs
+++ b/embedded-hal-async/src/digital.rs
@@ -15,9 +15,10 @@
 //!         .expect("failed to await input pin")
 //! }
 //! ```
+pub use embedded_hal::digital::{Error, ErrorKind, ErrorType};
 
 /// Asynchronously wait for GPIO pin state.
-pub trait Wait: embedded_hal::digital::ErrorType {
+pub trait Wait: ErrorType {
     /// Wait until the pin is high. If it is already high, return immediately.
     ///
     /// # Note for implementers

--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -16,9 +16,9 @@
 //! Since 7-bit addressing is the mode of the majority of I2C devices,
 //! `SevenBitAddress` has been set as default mode and thus can be omitted if desired.
 
-pub use embedded_hal::i2c::Operation;
 pub use embedded_hal::i2c::{
-    AddressMode, Error, ErrorKind, ErrorType, NoAcknowledgeSource, SevenBitAddress, TenBitAddress,
+    AddressMode, Error, ErrorKind, ErrorType, NoAcknowledgeSource, Operation, SevenBitAddress,
+    TenBitAddress,
 };
 
 /// Async I2c.


### PR DESCRIPTION
Align with other modules, which also re-export these `embedded_hal` types.