### PR TITLE
e-h-bus/spi: Require infallible chipselect pins

### DIFF
--- a/embedded-hal-bus/src/lib.rs
+++ b/embedded-hal-bus/src/lib.rs
@@ -18,3 +18,38 @@ use defmt_03 as defmt;
 
 pub mod i2c;
 pub mod spi;
+
+/// This adapter will [panic] if the inner device encounters an error.
+///
+/// It currently supports [embedded_hal::digital::OutputPin], but other traits may be added in the future.
+///
+/// TODO: add usage example
+#[repr(transparent)]
+pub struct UnwrappingAdapter<T>(pub T);
+
+impl<T> embedded_hal::digital::ErrorType for UnwrappingAdapter<T> {
+    type Error = core::convert::Infallible;
+}
+
+impl<T> embedded_hal::digital::OutputPin for UnwrappingAdapter<T>
+where
+    T: embedded_hal::digital::OutputPin,
+{
+    #[inline]
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.0.set_low().unwrap();
+        Ok(())
+    }
+
+    #[inline]
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.0.set_high().unwrap();
+        Ok(())
+    }
+
+    #[inline]
+    fn set_state(&mut self, state: embedded_hal::digital::PinState) -> Result<(), Self::Error> {
+        self.0.set_state(state).unwrap();
+        Ok(())
+    }
+}

--- a/embedded-hal-bus/src/spi/critical_section.rs
+++ b/embedded-hal-bus/src/spi/critical_section.rs
@@ -1,10 +1,10 @@
 use core::cell::RefCell;
+use core::convert::Infallible;
 use critical_section::Mutex;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 
-use super::DeviceError;
 use crate::spi::shared::transaction;
 
 /// `critical-section`-based shared bus [`SpiDevice`] implementation.
@@ -61,15 +61,15 @@ impl<'a, BUS, CS> CriticalSectionDevice<'a, BUS, CS, super::NoDelay> {
 impl<'a, BUS, CS, D> ErrorType for CriticalSectionDevice<'a, BUS, CS, D>
 where
     BUS: ErrorType,
-    CS: OutputPin,
+    CS: OutputPin<Error = Infallible>,
 {
-    type Error = DeviceError<BUS::Error, CS::Error>;
+    type Error = BUS::Error;
 }
 
 impl<'a, Word: Copy + 'static, BUS, CS, D> SpiDevice<Word> for CriticalSectionDevice<'a, BUS, CS, D>
 where
     BUS: SpiBus<Word>,
-    CS: OutputPin,
+    CS: OutputPin<Error = Infallible>,
     D: DelayNs,
 {
     #[inline]

--- a/embedded-hal-bus/src/spi/mod.rs
+++ b/embedded-hal-bus/src/spi/mod.rs
@@ -1,7 +1,6 @@
 //! `SpiDevice` implementations.
 
 use core::fmt::Debug;
-use embedded_hal::spi::{Error, ErrorKind};
 
 mod exclusive;
 pub use exclusive::*;
@@ -18,30 +17,6 @@ pub use self::critical_section::*;
 
 #[cfg(feature = "defmt-03")]
 use crate::defmt;
-
-/// Error type for [`ExclusiveDevice`] operations.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
-pub enum DeviceError<BUS, CS> {
-    /// An inner SPI bus operation failed.
-    Spi(BUS),
-    /// Asserting or deasserting CS failed.
-    Cs(CS),
-}
-
-impl<BUS, CS> Error for DeviceError<BUS, CS>
-where
-    BUS: Error + Debug,
-    CS: Debug,
-{
-    #[inline]
-    fn kind(&self) -> ErrorKind {
-        match self {
-            Self::Spi(e) => e.kind(),
-            Self::Cs(_) => ErrorKind::ChipSelectFault,
-        }
-    }
-}
 
 /// Dummy [`DelayNs`](embedded_hal::delay::DelayNs) implementation that panics on use.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/embedded-hal-bus/src/spi/mutex.rs
+++ b/embedded-hal-bus/src/spi/mutex.rs
@@ -1,9 +1,10 @@
+use core::convert::Infallible;
+
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 use std::sync::Mutex;
 
-use super::DeviceError;
 use crate::spi::shared::transaction;
 
 /// `std` `Mutex`-based shared bus [`SpiDevice`] implementation.
@@ -59,15 +60,15 @@ impl<'a, BUS, CS> MutexDevice<'a, BUS, CS, super::NoDelay> {
 impl<'a, BUS, CS, D> ErrorType for MutexDevice<'a, BUS, CS, D>
 where
     BUS: ErrorType,
-    CS: OutputPin,
+    CS: OutputPin<Error = Infallible>,
 {
-    type Error = DeviceError<BUS::Error, CS::Error>;
+    type Error = BUS::Error;
 }
 
 impl<'a, Word: Copy + 'static, BUS, CS, D> SpiDevice<Word> for MutexDevice<'a, BUS, CS, D>
 where
     BUS: SpiBus<Word>,
-    CS: OutputPin,
+    CS: OutputPin<Error = Infallible>,
     D: DelayNs,
 {
     #[inline]

--- a/embedded-hal-bus/src/spi/refcell.rs
+++ b/embedded-hal-bus/src/spi/refcell.rs
@@ -1,9 +1,9 @@
 use core::cell::RefCell;
+use core::convert::Infallible;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::OutputPin;
 use embedded_hal::spi::{ErrorType, Operation, SpiBus, SpiDevice};
 
-use super::DeviceError;
 use crate::spi::shared::transaction;
 
 /// `RefCell`-based shared bus [`SpiDevice`] implementation.
@@ -58,15 +58,15 @@ impl<'a, BUS, CS> RefCellDevice<'a, BUS, CS, super::NoDelay> {
 impl<'a, BUS, CS, D> ErrorType for RefCellDevice<'a, BUS, CS, D>
 where
     BUS: ErrorType,
-    CS: OutputPin,
+    CS: OutputPin<Error = Infallible>,
 {
-    type Error = DeviceError<BUS::Error, CS::Error>;
+    type Error = BUS::Error;
 }
 
 impl<'a, Word: Copy + 'static, BUS, CS, D> SpiDevice<Word> for RefCellDevice<'a, BUS, CS, D>
 where
     BUS: SpiBus<Word>,
-    CS: OutputPin,
+    CS: OutputPin<Error = Infallible>,
     D: DelayNs,
 {
     #[inline]


### PR DESCRIPTION
Fixes #573

- [x] Require infallible chipselect pins
- [x] Add an unwrapping adapter
	- [ ] Think of a good name for the adapter
- [ ] Add documentation
- [ ] Update changelog