### PR TITLE
embedded-hal-bus: Implement `Display` and `std::error::Error` for `DeviceError` if possible.

### DIFF
--- a/embedded-hal-bus/README.md
+++ b/embedded-hal-bus/README.md
@@ -30,7 +30,8 @@ provides mechanisms to obtain multiple `I2c` instances out of a single `I2c` ins
 
 ## Optional Cargo features
 
-- **`std`**: enable shared bus implementations using `std::sync::Mutex`.
+- **`std`**: enable shared bus implementations using `std::sync::Mutex`, and implement
+  `std::error::Error` for `DeviceError`.
 - **`async`**: enable `embedded-hal-async` support.
 - **`defmt-03`**: Derive `defmt::Format` from `defmt` 0.3 for enums and structs.
 

--- a/embedded-hal-bus/src/spi/mod.rs
+++ b/embedded-hal-bus/src/spi/mod.rs
@@ -1,6 +1,6 @@
 //! `SpiDevice` implementations.
 
-use core::fmt::Debug;
+use core::fmt::{self, Debug, Display, Formatter};
 use embedded_hal::spi::{Error, ErrorKind};
 
 mod exclusive;
@@ -28,6 +28,18 @@ pub enum DeviceError<BUS, CS> {
     /// Asserting or deasserting CS failed.
     Cs(CS),
 }
+
+impl<BUS: Display, CS: Display> Display for DeviceError<BUS, CS> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Spi(bus) => write!(f, "SPI bus error: {}", bus),
+            Self::Cs(cs) => write!(f, "SPI CS error: {}", cs),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<BUS: Debug + Display, CS: Debug + Display> std::error::Error for DeviceError<BUS, CS> {}
 
 impl<BUS, CS> Error for DeviceError<BUS, CS>
 where


### PR DESCRIPTION
This makes error handling more convenient on platforms where std is available.