### PR TITLE
Add async API for CAN

### DIFF
--- a/embedded-can/CHANGELOG.md
+++ b/embedded-can/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - `as_raw_unchecked` getter function for `Id`
+- Add async API.
 
 ## [v0.4.1] - 2022-09-28
 

--- a/embedded-can/src/asynch.rs
+++ b/embedded-can/src/asynch.rs
@@ -1,17 +1,26 @@
 //! Async CAN API
 
-/// An async CAN interface that is able to transmit and receive frames.
-pub trait Can {
+/// An async CAN interface that is able to transmit frames.
+pub trait CanTx {
     /// Associated frame type.
     type Frame: crate::Frame;
 
     /// Associated error type.
     type Error: crate::Error;
 
-    /// Puts a frame in the transmit buffer.
-    /// Awaits until space is available in the transmit buffer.
+    /// Puts a frame in the transmit buffer or awaits until space is available
+    /// in the transmit buffer.
     async fn transmit(&mut self, frame: &Self::Frame) -> Result<(), Self::Error>;
+}
 
-    /// Awaits until a frame was received or an error occurred.
+/// An async CAN interface that is able to receive frames.
+pub trait CanRx {
+    /// Associated frame type.
+    type Frame: crate::Frame;
+
+    /// Associated error type.
+    type Error: crate::Error;
+
+    /// Awaits until a frame was received or an error occurs.
     async fn receive(&mut self) -> Result<Self::Frame, Self::Error>;
 }

--- a/embedded-can/src/asynch.rs
+++ b/embedded-can/src/asynch.rs
@@ -12,14 +12,6 @@ pub trait Can {
     /// Awaits until space is available in the transmit buffer.
     async fn transmit(&mut self, frame: &Self::Frame) -> Result<(), Self::Error>;
 
-    /// Tries to put a frame in the transmit buffer.
-    /// If no space is available in the transmit buffer `None` is returned.
-    fn try_transmit(&mut self, frame: &Self::Frame) -> Option<Result<(), Self::Error>>;
-
     /// Awaits until a frame was received or an error occurred.
     async fn receive(&mut self) -> Result<Self::Frame, Self::Error>;
-
-    /// Tries to receive a frame from the receive buffer.
-    /// If no frame is available `None` is returned.
-    fn try_receive(&mut self) -> Option<Result<Self::Frame, Self::Error>>;
 }

--- a/embedded-can/src/asynch.rs
+++ b/embedded-can/src/asynch.rs
@@ -1,0 +1,25 @@
+//! Async CAN API
+
+/// An async CAN interface that is able to transmit and receive frames.
+pub trait Can {
+    /// Associated frame type.
+    type Frame: crate::Frame;
+
+    /// Associated error type.
+    type Error: crate::Error;
+
+    /// Puts a frame in the transmit buffer.
+    /// Awaits until space is available in the transmit buffer.
+    async fn transmit(&mut self, frame: &Self::Frame) -> Result<(), Self::Error>;
+
+    /// Tries to put a frame in the transmit buffer.
+    /// If no space is available in the transmit buffer `None` is returned.
+    fn try_transmit(&mut self, frame: &Self::Frame) -> Option<Result<(), Self::Error>>;
+
+    /// Awaits until a frame was received or an error occurred.
+    async fn receive(&mut self) -> Result<Self::Frame, Self::Error>;
+
+    /// Tries to receive a frame from the receive buffer.
+    /// If no frame is available `None` is returned.
+    fn try_receive(&mut self) -> Option<Result<Self::Frame, Self::Error>>;
+}

--- a/embedded-can/src/asynch.rs
+++ b/embedded-can/src/asynch.rs
@@ -1,5 +1,7 @@
 //! Async CAN API
 
+use core::future::Future;
+
 /// An async CAN interface that is able to transmit frames.
 pub trait CanTx {
     /// Associated frame type.
@@ -10,7 +12,7 @@ pub trait CanTx {
 
     /// Puts a frame in the transmit buffer or awaits until space is available
     /// in the transmit buffer.
-    async fn transmit(&mut self, frame: &Self::Frame) -> Result<(), Self::Error>;
+    fn transmit(&mut self, frame: &Self::Frame) -> impl Future<Output = Result<(), Self::Error>>;
 }
 
 /// An async CAN interface that is able to receive frames.
@@ -22,5 +24,5 @@ pub trait CanRx {
     type Error: crate::Error;
 
     /// Awaits until a frame was received or an error occurs.
-    async fn receive(&mut self) -> Result<Self::Frame, Self::Error>;
+    fn receive(&mut self) -> impl Future<Output = Result<Self::Frame, Self::Error>>;
 }

--- a/embedded-can/src/asynch.rs
+++ b/embedded-can/src/asynch.rs
@@ -12,7 +12,15 @@ pub trait CanTx {
 
     /// Puts a frame in the transmit buffer or awaits until space is available
     /// in the transmit buffer.
-    fn transmit(&mut self, frame: &Self::Frame) -> impl Future<Output = Result<(), Self::Error>>;
+    ///
+    /// If the transmit buffer is full, this function will try to replace a
+    /// pending lower priority frame and return the frame that was replaced. If
+    /// no lower-priority frames can be replaced, this call should wait for a
+    /// frame to be transmitted and then try again.
+    fn transmit(
+        &mut self,
+        frame: &Self::Frame,
+    ) -> impl Future<Output = Result<Option<Self::Frame>, Self::Error>>;
 }
 
 /// An async CAN interface that is able to receive frames.

--- a/embedded-can/src/lib.rs
+++ b/embedded-can/src/lib.rs
@@ -2,6 +2,12 @@
 
 #![warn(missing_docs)]
 #![no_std]
+// disable warning for already-stabilized features.
+// Needed to pass CI, because we deny warnings.
+// We don't immediately remove them to not immediately break older nightlies.
+// When all features are stable, we'll remove them.
+#![cfg_attr(nightly, allow(stable_features, unknown_lints))]
+#![cfg_attr(nightly, feature(async_fn_in_trait, impl_trait_projections))]
 #![allow(async_fn_in_trait)]
 
 pub mod asynch;

--- a/embedded-can/src/lib.rs
+++ b/embedded-can/src/lib.rs
@@ -2,7 +2,9 @@
 
 #![warn(missing_docs)]
 #![no_std]
+#![allow(async_fn_in_trait)]
 
+pub mod asynch;
 pub mod blocking;
 pub mod nb;
 

--- a/embedded-can/src/lib.rs
+++ b/embedded-can/src/lib.rs
@@ -2,12 +2,6 @@
 
 #![warn(missing_docs)]
 #![no_std]
-// disable warning for already-stabilized features.
-// Needed to pass CI, because we deny warnings.
-// We don't immediately remove them to not immediately break older nightlies.
-// When all features are stable, we'll remove them.
-#![cfg_attr(nightly, allow(stable_features, unknown_lints))]
-#![cfg_attr(nightly, feature(async_fn_in_trait, impl_trait_projections))]
 #![allow(async_fn_in_trait)]
 
 pub mod asynch;

--- a/embedded-can/src/lib.rs
+++ b/embedded-can/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![warn(missing_docs)]
 #![no_std]
-#![allow(async_fn_in_trait)]
 
 pub mod asynch;
 pub mod blocking;


### PR DESCRIPTION
Adds a new CAN trait with both async and fallback non-blocking methods.

Module is named `asynch` to avoid a collision with the `async` keyword. Alternatively a separate crate `embedded-can-async` could be published.
