### PR TITLE
Release embedded-hal-bus v0.2.0

### DIFF
--- a/embedded-hal-bus/CHANGELOG.md
+++ b/embedded-hal-bus/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+(Add unreleased changes here)
+
+## [v0.2.0] - 2024-04-23
+
 - Added a new `AtomicDevice` for I2C and SPI to enable bus sharing across multiple contexts.
 - SPI shared bus constructors now set `CS` high, to prevent sharing issues if it was low.
 
@@ -57,7 +61,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 First release to crates.io
 
-[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.2.0...HEAD
+[v0.2.0]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0...embedded-hal-bus-v0.2.0
 [v0.1.0]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-rc.3...embedded-hal-bus-v0.1.0
 [v0.1.0-rc.3]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-rc.2...embedded-hal-bus-v0.1.0-rc.3
 [v0.1.0-rc.2]: https://github.com/rust-embedded/embedded-hal/compare/embedded-hal-bus-v0.1.0-rc.1...embedded-hal-bus-v0.1.0-rc.2

--- a/embedded-hal-bus/Cargo.toml
+++ b/embedded-hal-bus/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "embedded-hal-bus"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/embedded-hal"
-version = "0.1.0"
+version = "0.2.0"
 
 [features]
 std = []


### PR DESCRIPTION
Depends on #594.

Needs to be v0.2 because #594 is breaking.

- **bus: make constructors set CS high.**
- **Release embedded-hal-bus v0.2.0**
