### PR TITLE
Add defmt feature and traits for embedded-can

### DIFF
--- a/embedded-can/Cargo.toml
+++ b/embedded-can/Cargo.toml
@@ -14,3 +14,7 @@ repository = "https://github.com/rust-embedded/embedded-hal"
 
 [dependencies]
 nb = "1"
+defmt = { version = "0.3", optional = true }
+
+[features]
+defmt-03 = ["dep:defmt"]

--- a/embedded-can/README.md
+++ b/embedded-can/README.md
@@ -13,6 +13,10 @@ This project is developed and maintained by the [HAL team](https://github.com/ru
 
 [API reference]: https://docs.rs/embedded-can
 
+## Optional features
+
+- **`defmt-03`**: Derive `defmt::Format` from `defmt` 0.3 for enums and structs.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*

--- a/embedded-can/src/id.rs
+++ b/embedded-can/src/id.rs
@@ -2,6 +2,7 @@
 
 /// Standard 11-bit CAN Identifier (`0..=0x7FF`).
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct StandardId(u16);
 
 impl StandardId {
@@ -44,6 +45,7 @@ impl StandardId {
 
 /// Extended 29-bit CAN Identifier (`0..=1FFF_FFFF`).
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct ExtendedId(u32);
 
 impl ExtendedId {
@@ -93,6 +95,7 @@ impl ExtendedId {
 
 /// A CAN Identifier (standard or extended).
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Id {
     /// Standard 11-bit Identifier (`0..=0x7FF`).
     Standard(StandardId),

--- a/embedded-can/src/lib.rs
+++ b/embedded-can/src/lib.rs
@@ -73,6 +73,7 @@ impl Error for core::convert::Infallible {
 /// free to define more specific or additional error types. However, by providing
 /// a mapping to these common CAN errors, generic code can still react to them.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum ErrorKind {
     /// The peripheral receive buffer was overrun.


### PR DESCRIPTION
Adds a feature `defmt-03` and derives Format for applicable types.