### PR TITLE
Update minimum `embedded-io` version for `embedded-io-async`

### DIFF
--- a/embedded-io-async/Cargo.toml
+++ b/embedded-io-async/Cargo.toml
@@ -18,7 +18,7 @@ alloc = ["embedded-io/alloc"]
 defmt-03 = ["dep:defmt-03", "embedded-io/defmt-03"]
 
 [dependencies]
-embedded-io = { version = "0.6", path = "../embedded-io" }
+embedded-io = { version = "0.6.1", path = "../embedded-io" }
 defmt-03 = { package = "defmt", version = "0.3", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
The 0.6.0 version of `embedded-io` does not have `SliceWriteError` in the public API, leading to this error if the 0.6.0 version is selected:

```
error[E0432]: unresolved import `embedded_io::SliceWriteError`
 --> /Users/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/embedded-io-async-0.6.1/src/impls/slice_mut.rs:2:5
  |
2 | use embedded_io::SliceWriteError;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `SliceWriteError` in the root

For more information about this error, try `rustc --explain E0432`.
error: could not compile `embedded-io-async` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

This means that embedded-io-async requires *at least* embedded-io 0.6.