### PR TITLE
Clarify I2C transaction contract for NACK behavior

### DIFF
--- a/embedded-hal-async/src/i2c.rs
+++ b/embedded-hal-async/src/i2c.rs
@@ -112,7 +112,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - Data from adjacent operations of the same type are sent after each other without an SP or SR.
     /// - Between adjacent operations of a different type an SR and SAD+R/W is sent.
     /// - After executing the last operation an SP is sent automatically.
-    /// - If the last operation is a `Read` the master does not send an acknowledge for the last byte.
+    /// - At the end of each read operation (before SP or SR), the master does not send an acknowledge for the last byte.
     ///
     /// - `ST` = start condition
     /// - `SAD+R/W` = slave address followed by bit 1 to indicate reading or 0 to indicate writing

--- a/embedded-hal/src/i2c.rs
+++ b/embedded-hal/src/i2c.rs
@@ -392,7 +392,7 @@ pub trait I2c<A: AddressMode = SevenBitAddress>: ErrorType {
     /// - Data from adjacent operations of the same type are sent after each other without an SP or SR.
     /// - Between adjacent operations of a different type an SR and SAD+R/W is sent.
     /// - After executing the last operation an SP is sent automatically.
-    /// - If the last operation is a `Read` the master does not send an acknowledge for the last byte.
+    /// - At the end of each read operation (before SP or SR), the master does not send an acknowledge for the last byte.
     ///
     /// - `ST` = start condition
     /// - `SAD+R/W` = slave address followed by bit 1 to indicate reading or 0 to indicate writing


### PR DESCRIPTION
Update the I2C trait documentation in both embedded-hal and embedded-hal-async to clarify the NACK (No Acknowledge) behavior during read operations.

The previous wording suggested that a NACK was only sent for the last byte of the final read operation in a transaction. This has been corrected to specify that a NACK should be sent at the end of each read operation, whether it's followed by a stop condition or a repeated start condition.

This change ensures correct implementation of the I2C protocol across different scenarios and prevents potential communication errors.

Changes:
- Updated comment in embedded-hal/src/i2c.rs
- Updated comment in embedded-hal-async/src/i2c.rs

fix #621 