### PR TITLE
Clarify Read trait blocking behavior

### DIFF
--- a/embedded-io-async/src/lib.rs
+++ b/embedded-io-async/src/lib.rs
@@ -19,12 +19,23 @@ pub use embedded_io::{
 pub trait Read: ErrorType {
     /// Read some bytes from this source into the specified buffer, returning how many bytes were read.
     ///
-    /// If no bytes are currently available to read, this function waits until at least one byte is available.
+    /// If no bytes are currently available to read:
+    /// - The method waits until at least one byte becomes available;
+    /// - Once at least one (or more) bytes become available, a non-zero amount of those is copied to the
+    ///   beginning of `buf`, and the amount is returned, *without waiting any further for more bytes to
+    ///   become available*.
     ///
-    /// If bytes are available, a non-zero amount of bytes is read to the beginning of `buf`, and the amount
-    /// is returned. It is not guaranteed that *all* available bytes are returned, it is possible for the
-    /// implementation to read an amount of bytes less than `buf.len()` while there are more bytes immediately
-    /// available.
+    /// If bytes are available to read:
+    /// - A non-zero amount of bytes is read to the beginning of `buf`, and the amount is returned immediately,
+    ///   *without waiting for more bytes to become available*;
+    /// - It is not guaranteed that *all* available bytes are returned, it is possible for the implementation to
+    ///   read an amount of bytes less than `buf.len()` while there are more bytes immediately available.
+    ///
+    /// This waiting behavior is important for the cases where `Read` represents the "read" leg of a pipe-like
+    /// protocol (a socket, a pipe, a serial line etc.). The semantics is that the caller - by passing a non-empty
+    /// buffer - does expect _some_ data (one or more bytes) - but _not necessarily `buf.len()` or more bytes_ -
+    /// to become available, before the peer represented by `Read` would stop sending bytes due to
+    /// application-specific reasons (as in the peer waiting for a response to the data it had sent so far).
     ///
     /// If the reader is at end-of-file (EOF), `Ok(0)` is returned. There is no guarantee that a reader at EOF
     /// will always be so in the future, for example a reader can stop being at EOF if another process appends

--- a/embedded-io-async/src/lib.rs
+++ b/embedded-io-async/src/lib.rs
@@ -28,8 +28,10 @@ pub trait Read: ErrorType {
     /// If bytes are available to read:
     /// - A non-zero amount of bytes is read to the beginning of `buf`, and the amount is returned immediately,
     ///   *without waiting for more bytes to become available*;
-    /// - It is not guaranteed that *all* available bytes are returned, it is possible for the implementation to
-    ///   read an amount of bytes less than `buf.len()` while there are more bytes immediately available.
+    ///
+    /// Note that once some bytes are available to read, it is *not* guaranteed that all available bytes are returned.
+    /// It is possible for the implementation to read an amount of bytes less than `buf.len()` while there are more
+    /// bytes immediately available.
     ///
     /// This waiting behavior is important for the cases where `Read` represents the "read" leg of a pipe-like
     /// protocol (a socket, a pipe, a serial line etc.). The semantics is that the caller - by passing a non-empty

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -309,8 +309,10 @@ pub trait Read: ErrorType {
     /// If bytes are available to read:
     /// - A non-zero amount of bytes is read to the beginning of `buf`, and the amount is returned immediately,
     ///   *without blocking and waiting for more bytes to become available*;
-    /// - It is not guaranteed that *all* available bytes are returned, it is possible for the implementation to
-    ///   read an amount of bytes less than `buf.len()` while there are more bytes immediately available.
+    ///
+    /// Note that once some bytes are available to read, it is *not* guaranteed that all available bytes are returned.
+    /// It is possible for the implementation to read an amount of bytes less than `buf.len()` while there are more
+    /// bytes immediately available.
     ///
     /// This blocking behavior is important for the cases where `Read` represents the "read" leg of a pipe-like
     /// protocol (a socket, a pipe, a serial line etc.). The semantics is that the caller - by passing a non-empty

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -300,16 +300,23 @@ impl<E: fmt::Debug> std::error::Error for WriteFmtError<E> {}
 pub trait Read: ErrorType {
     /// Read some bytes from this source into the specified buffer, returning how many bytes were read.
     ///
-    /// If no bytes are currently available to read, this function blocks until at least one byte is available.
+    /// If no bytes are currently available to read:
+    /// - The method blocks until at least one byte becomes available;
+    /// - Once at least one (or more) bytes become available, a non-zero amount of those is read to the
+    ///   beginning of `buf`, and the amount is returned, *without waiting or blocking any further for
+    ///   more bytes to become available*.
     ///
-    /// If bytes are available, a non-zero amount of bytes is read to the beginning of `buf`, and the amount
-    /// is returned. It is not guaranteed that *all* available bytes are returned, it is possible for the
-    /// implementation to read an amount of bytes less than `buf.len()` while there are more bytes immediately
-    /// available.
+    /// If bytes are available to read:
+    /// - A non-zero amount of bytes is read to the beginning of `buf`, and the amount is returned immediately,
+    ///   *without blocking and waiting for more bytes to become available*;
+    /// - It is not guaranteed that *all* available bytes are returned, it is possible for the implementation to
+    ///   read an amount of bytes less than `buf.len()` while there are more bytes immediately available.
     ///
-    /// If the reader is at end-of-file (EOF), `Ok(0)` is returned. There is no guarantee that a reader at EOF
-    /// will always be so in the future, for example a reader can stop being at EOF if another process appends
-    /// more bytes to the underlying file.
+    /// This blocking behavior is important for the cases where `Read` represents the "read" leg of a pipe-like
+    /// protocol (a socket, a pipe, a serial line etc.). The semantics is that the caller - by passing a non-empty
+    /// buffer - does expect _some_ data (one or more bytes) - but _not necessarily `buf.len()` or more bytes_ -
+    /// to become available, before the peer represented by `Read` would stop sending bytes due to
+    /// application-specific reasons (as in the peer waiting for a response to the data it had sent so far).
     ///
     /// If `buf.len() == 0`, `read` returns without blocking, with either `Ok(0)` or an error.
     /// The `Ok(0)` doesn't indicate EOF, unlike when called with a non-empty buffer.

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -318,6 +318,10 @@ pub trait Read: ErrorType {
     /// to become available, before the peer represented by `Read` would stop sending bytes due to
     /// application-specific reasons (as in the peer waiting for a response to the data it had sent so far).
     ///
+    /// If the reader is at end-of-file (EOF), `Ok(0)` is returned. There is no guarantee that a reader at EOF
+    /// will always be so in the future, for example a reader can stop being at EOF if another process appends
+    /// more bytes to the underlying file.
+    ///
     /// If `buf.len() == 0`, `read` returns without blocking, with either `Ok(0)` or an error.
     /// The `Ok(0)` doesn't indicate EOF, unlike when called with a non-empty buffer.
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error>;

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -302,7 +302,7 @@ pub trait Read: ErrorType {
     ///
     /// If no bytes are currently available to read:
     /// - The method blocks until at least one byte becomes available;
-    /// - Once at least one (or more) bytes become available, a non-zero amount of those is read to the
+    /// - Once at least one (or more) bytes become available, a non-zero amount of those is copied to the
     ///   beginning of `buf`, and the amount is returned, *without waiting or blocking any further for
     ///   more bytes to become available*.
     ///


### PR DESCRIPTION
This PR is an effort to clarify the blocking behavior of the `Read` trait with regards to the length of the user-supplied buffer.

It is a follow up on a recent discussion in the ["Rust Embedded" Matrix chat](https://matrix.to/#/!BHcierreUuwCMxVqOf:matrix.org/$KPz0XkHW0cQt2bAG2-8pGvzZNMSeZlTJlVTBlVVVEvY?via=matrix.org&via=catircservices.org&via=tchncs.de) where the agreement was that we could probably be more explicit about that.

For now, I've changed only the documentation of the blocking `Read` trait. Once/if we arrive at a text which seems reasonable to everybody, I'll extend the PR with a similar change to `embedded_io_async::Read`.

Ideally, we should arrive at a piece of documentation that we could also justify to be included upstream [in the Rust STD Read trait as well](https://github.com/rust-lang/rust/blob/edbc000fa4413f9ff92f4e5492f8ff497716ce48/library/std/src/io/mod.rs#L595), and possibly in its `async` variants in the `futures` and `tokio` crates.

