### PR TITLE
i2c: AddressMode: add bound Copy

### DIFF
--- a/embedded-hal/src/i2c.rs
+++ b/embedded-hal/src/i2c.rs
@@ -276,7 +276,7 @@ impl<T: ErrorType + ?Sized> ErrorType for &mut T {
 /// Address mode (7-bit / 10-bit).
 ///
 /// Note: This trait is sealed and should not be implemented outside of this crate.
-pub trait AddressMode: private::Sealed + 'static {}
+pub trait AddressMode: Copy + 'static + private::Sealed {}
 
 /// 7-bit address mode type.
 ///


### PR DESCRIPTION
Since the trait `AddressMode` is `Sealed`, and only implemented on `Copy` types (`u8` and `u16`), there isn't any reason for the trait not to be bound also as `Copy`. This makes multiple-consumption much easier, and does not require calling code to add extra bounds.