### PR TITLE
embedded-can: Update readme to reflect MSRV specified in Cargo.toml

### DIFF
--- a/embedded-can/README.md
+++ b/embedded-can/README.md
@@ -19,7 +19,7 @@ This project is developed and maintained by the [HAL team](https://github.com/ru
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.81 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 See [here](../docs/msrv.md) for details on how the MSRV may be upgraded.


### PR DESCRIPTION
It looks like the `embedded-can` readme was missed when updating the MSRV to include `core::error::Error`.