### PR TITLE
Disable misguided clippy lint

### DIFF
--- a/embedded-hal-nb/src/serial.rs
+++ b/embedded-hal-nb/src/serial.rs
@@ -124,6 +124,9 @@ where
 {
     #[inline]
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        // The iteration has side-effects so using
+        // `next_back()` instead of `last()` would be wrong
+        #[allow(clippy::double_ended_iterator_last)]
         let _ = s
             .bytes()
             .map(|c| nb::block!(self.write(Word::from(c))))


### PR DESCRIPTION
Disables this warning and its wrong suggestion:
```
warning: called `Iterator::last` on a `DoubleEndedIterator`; this will needlessly iterate the entire iterator
   --> embedded-hal-nb/src/serial.rs:127:17
    |
127 |           let _ = s
    |  _________________^
128 | |             .bytes()
129 | |             .map(|c| nb::block!(self.write(Word::from(c))))
130 | |             .last();
    | |______________-----^
    |                |
    |                help: try: `next_back()`
    |
    = note: this change will alter drop order which may be undesirable
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last
    = note: `#[warn(clippy::double_ended_iterator_last)]` on by default
```