### PR TITLE
nb: do not swallow errors in fmt::Write.

### DIFF
--- a/embedded-hal-nb/src/serial.rs
+++ b/embedded-hal-nb/src/serial.rs
@@ -124,10 +124,9 @@ where
 {
     #[inline]
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        let _ = s
-            .bytes()
-            .map(|c| nb::block!(self.write(Word::from(c))))
-            .next_back();
+        for c in s.bytes() {
+            nb::block!(self.write(Word::from(c))).map_err(|_| core::fmt::Error)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Errors were silently swallowed before.

Also fixes clippy lint due to using `map` for the side-effect.

Closes #655
