### PR TITLE
Add I2C clock low timeout error kind

### DIFF
--- a/embedded-hal/CHANGELOG.md
+++ b/embedded-hal/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `core::error::Error` implementations for every custom `impl Error`
 - Increased MSRV to 1.81 due to `core::error::Error`
 
+## Added
+
+- `i2c::ErrorKind::ClkLowTimeout` error kind.
+
 ## [v1.0.0] - 2023-12-28
 
 Check out the [announcement blog post](https://blog.rust-embedded.org/embedded-hal-v1/) and the [migration guide](../docs/migrating-from-0.2-to-1.0.md) for help with migrating from v0.2 to v1.0.

--- a/embedded-hal/src/i2c.rs
+++ b/embedded-hal/src/i2c.rs
@@ -203,6 +203,8 @@ pub enum ErrorKind {
     NoAcknowledge(NoAcknowledgeSource),
     /// The peripheral receive buffer was overrun.
     Overrun,
+    /// A clock low timeout occured.
+    ClkLowTimeout,
     /// A different error occurred. The original error may contain more information.
     Other,
 }
@@ -242,6 +244,7 @@ impl core::fmt::Display for ErrorKind {
             Self::ArbitrationLoss => write!(f, "The arbitration was lost"),
             Self::NoAcknowledge(s) => s.fmt(f),
             Self::Overrun => write!(f, "The peripheral receive buffer was overrun"),
+            Self::ClkLowTimeout => write!(f, "The peripheral had a clock low timeout"),
             Self::Other => write!(
                 f,
                 "A different error occurred. The original error may contain more information"


### PR DESCRIPTION
Many I2C peripherals support a clock low timeout to prevent bus stalls/  hangups. I think this error variant would be useful.