### PR TITLE
io: Require core::error::Error for the Error trait

### DIFF
--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -176,7 +176,7 @@ impl From<std::io::ErrorKind> for ErrorKind {
 ///
 /// This trait allows generic code to do limited inspecting of errors,
 /// to react differently to different kinds.
-pub trait Error: fmt::Debug {
+pub trait Error: fmt::Debug + core::error::Error {
     /// Get the kind of this error.
     fn kind(&self) -> ErrorKind;
 }


### PR DESCRIPTION
Unlike #630 (which merely implemented the then-stabilized core:…:Error on types), this would be a breaking change (spooling for https://github.com/rust-embedded/embedded-hal/issues/566), but contributes to the idiomatic usability of our error types because all conversions through core:…:Error are thus available easily.

This is "only breaking for implementers of the trait" – that's not a thing in semver, but can be a relevant piece of changelog information if all our changes for >>0.6 are.