### PR TITLE
io: Update defmt to 1.0, rename feature from "defmt_03" to "defmt"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           cargo build
           --workspace
           --target thumbv7m-none-eabi
-          --features async,defmt-03
+          --features async,defmt-03,embedded-io/defmt,embedded-io-async/defmt
 
   msrv-1-81:
     runs-on: ubuntu-latest

--- a/embedded-io-async/Cargo.toml
+++ b/embedded-io-async/Cargo.toml
@@ -15,11 +15,11 @@ categories = [
 [features]
 std = ["alloc", "embedded-io/std"]
 alloc = ["embedded-io/alloc"]
-defmt-03 = ["dep:defmt-03", "embedded-io/defmt-03"]
+defmt = ["dep:defmt", "embedded-io/defmt"]
 
 [dependencies]
 embedded-io = { version = "0.6.1", path = "../embedded-io" }
-defmt-03 = { package = "defmt", version = "0.3", optional = true }
+defmt = { package = "defmt", version = "1", optional = true }
 
 [package.metadata.docs.rs]
 features = ["std"]

--- a/embedded-io-async/README.md
+++ b/embedded-io-async/README.md
@@ -14,7 +14,7 @@ This project is developed and maintained by the [HAL team](https://github.com/ru
 
 - **`std`**: Adds `From` impls to convert to/from `std::io` structs.
 - **`alloc`**: Adds blanket impls for `Box`, adds `Write` impl to `Vec`.
-- **`defmt-03`**: Derive `defmt::Format` from `defmt` 0.3 for enums and structs.
+- **`defmt`**: Derive `defmt::Format` from `defmt` 1.0 for enums and structs.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/embedded-io/Cargo.toml
+++ b/embedded-io/Cargo.toml
@@ -15,10 +15,10 @@ categories = [
 [features]
 std = ["alloc"]
 alloc = []
-defmt-03 = ["dep:defmt-03"]
+defmt = ["dep:defmt"]
 
 [dependencies]
-defmt-03 = { package = "defmt", version = "0.3", optional = true }
+defmt = { version = "1", optional = true }
 
 [package.metadata.docs.rs]
 features = ["std"]

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -5,10 +5,6 @@
 
 use core::fmt;
 
-// needed to prevent defmt macros from breaking, since they emit code that does `defmt::blahblah`.
-#[cfg(feature = "defmt-03")]
-use defmt_03 as defmt;
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
@@ -18,7 +14,7 @@ mod impls;
 ///
 /// This is the `embedded-io` equivalent of [`std::io::SeekFrom`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SeekFrom {
     /// Sets the offset to the provided number of bytes.
     Start(u64),
@@ -62,7 +58,7 @@ impl From<std::io::SeekFrom> for SeekFrom {
 ///
 /// - `WouldBlock` is removed, since `embedded-io` traits are always blocking. See the [crate-level documentation](crate) for details.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum ErrorKind {
     /// Unspecified error kind.
@@ -229,7 +225,7 @@ impl<T: ?Sized + ErrorType> ErrorType for &mut T {
 
 /// Error returned by [`Read::read_exact`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ReadExactError<E> {
     /// An EOF error was encountered before reading the exact amount of requested bytes.
     UnexpectedEof,
@@ -267,7 +263,7 @@ impl<E: fmt::Debug> core::error::Error for ReadExactError<E> {}
 
 /// Errors that could be returned by `Write` on `&mut [u8]`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum SliceWriteError {
     /// The target slice was full and so could not receive any new data.
@@ -276,7 +272,7 @@ pub enum SliceWriteError {
 
 /// Error returned by [`Write::write_fmt`]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WriteFmtError<E> {
     /// An error was encountered while formatting.
     FmtError,


### PR DESCRIPTION
We *could* do the defmt-1.0 update a bit more compatibly by just going to 0.3.100 (and possibly keeping the defmt_03 feature as a deprecated feature name), but given the discussion in https://github.com/rust-embedded/embedded-hal/issues/566#issuecomment-3148142408, it may make sense to spool this for a single breaking >>0.6 bump, and use that to get rid of anything that'd be viewed as legacy in a 1.0 version.

<del>One alternative to the hard cut would be to to keep a defmt_03 feature that merely pulls in 0.3.100, as a deprecated feature. If >>0.6 becomes a 0.7 that does the semver trick to 1.0, that feature could be removed as part of the 1.0 transition.</del>

An extra deprecated defmt-03 feature is left in place mainly for embedded-io-async, which optionally pulls it in through the path-or-version dependency.