### PR TITLE
implement Write for uninitialized slices

### DIFF
--- a/embedded-io-async/src/impls/slice_mut.rs
+++ b/embedded-io-async/src/impls/slice_mut.rs
@@ -43,13 +43,9 @@ impl Write for &mut [MaybeUninit<u8>] {
             return Err(SliceWriteError::Full);
         }
         let (a, b) = mem::take(self).split_at_mut(amt);
-        buf.split_at(amt)
-            .0
-            .iter()
-            .enumerate()
-            .for_each(|(index, byte)| {
-                a[index].write(*byte);
-            });
+        unsafe {
+            core::ptr::copy_nonoverlapping(buf.as_ptr(), a.as_mut_ptr() as *mut u8, amt);
+        }
         *self = b;
         Ok(amt)
     }

--- a/embedded-io/src/impls/slice_mut.rs
+++ b/embedded-io/src/impls/slice_mut.rs
@@ -75,13 +75,9 @@ impl Write for &mut [MaybeUninit<u8>] {
             return Err(SliceWriteError::Full);
         }
         let (a, b) = mem::take(self).split_at_mut(amt);
-        buf.split_at(amt)
-            .0
-            .iter()
-            .enumerate()
-            .for_each(|(index, byte)| {
-                a[index].write(*byte);
-            });
+        unsafe {
+            core::ptr::copy_nonoverlapping(buf.as_ptr(), a.as_mut_ptr() as *mut u8, amt);
+        }
         *self = b;
         Ok(amt)
     }


### PR DESCRIPTION
# background
similar to how we implement the `Write` traits on `&mut [u8]`, we can also add support for `&mut [MaybeUninit<u8>]` without using `unsafe`. could be especially useful with [core::io::BorrowedBuf](https://doc.rust-lang.org/core/io/struct.BorrowedBuf.html).

# changes
* implement `ErrorType`, `embedded_io::Write`, & `embedded_io_async::Write` for `&mut [MaybeUninit<u8>]`
* replace 2 existing usages of `&buf[..amt]` with `buf.split_at(amt).0` for consistency (and potential const-context compatibility)
* lil organization in embedded-io/src/impls/slice_mut.rs