### PR TITLE
e-io-adapters: Clarify scope in README

### DIFF
--- a/embedded-io-adapters/README.md
+++ b/embedded-io-adapters/README.md
@@ -27,6 +27,9 @@ For `embedded-io-async`:
 - [`futures` 0.3](https://crates.io/crates/futures) traits. Needs the `futures-03` feature.
 - [`tokio` 1.x](https://crates.io/crates/tokio) traits. Needs the `tokio-1` feature.
 
+As a rule of thumb, this crate will generally provide adapters for crates that are more stable and general-purpose than embedded-io,
+provided those crates implement the corresponding std traits.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile on stable Rust 1.60 and up. It *might*


### PR DESCRIPTION
This documents what I've learned about the crate's scope on the matrix channel talking to @dirbaio -- written in hope to avoid the need for further roundtrips when the question comes up next.