### PR TITLE
add adapters for digest trait

### DIFF
--- a/embedded-io-adapters/Cargo.toml
+++ b/embedded-io-adapters/Cargo.toml
@@ -13,11 +13,13 @@ categories = [
 ]
 
 [features]
+default = ["digest"]
 std = ["embedded-io/std"]
 tokio-1 = ["std", "dep:tokio", "dep:embedded-io-async", "embedded-io-async?/std"]
 futures-03 = ["std", "dep:futures", "dep:embedded-io-async", "embedded-io-async?/std"]
 
 [dependencies]
+digest = { version = "0.10.7", default-features = false, optional = true }
 embedded-io = { version = "0.6", path = "../embedded-io" }
 embedded-io-async = { version = "0.6.1", path = "../embedded-io-async", optional = true }
 

--- a/embedded-io-adapters/src/digest.rs
+++ b/embedded-io-adapters/src/digest.rs
@@ -1,0 +1,98 @@
+//! Adapters to/from `digest::Digest` traits e.g. sha2::Sha256
+
+use core::convert::Infallible;
+use digest::Update;
+use embedded_io::{ErrorType, Write};
+
+/// Adapter from `digest::Digest` traits.
+#[derive(Clone)]
+pub struct FromDigest<T: ?Sized> {
+    inner: T,
+}
+
+impl <T> FromDigest<T> {
+    /// Create a new adapter.
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    /// Consume the adapter, returning the inner object.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl <T: ?Sized> FromDigest<T> {
+    /// Borrow the inner object.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Mutably borrow the inner object.
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl <T> ErrorType for FromDigest<T> {
+    type Error = Infallible;
+}
+
+impl <T: Update> Write for FromDigest<T> {
+    fn write(&mut self, data: &[u8]) -> Result<usize, <Self as ErrorType>::Error> {
+        T::update(&mut self.inner, data);
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> Result<(), <Self as ErrorType>::Error> { Ok(()) }
+}
+
+impl <T: Default> Default for FromDigest<T> {
+    fn default() -> Self {
+        Self { inner: T::default() }
+    }
+}
+
+/// Adapter to `digest::Digest` traits.
+#[derive(Clone)]
+pub struct ToDigest<T: ?Sized> {
+    inner: T,
+}
+
+impl <T> ToDigest<T> {
+    /// Create a new adapter.
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    /// Consume the adapter, returning the inner object.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl <T: ?Sized> ToDigest<T> {
+    /// Borrow the inner object.
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Mutably borrow the inner object.
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl <T: Default> Default for ToDigest<T> {
+    fn default() -> Self {
+        Self { inner: T::default() }
+    }
+}
+
+impl <T: ErrorType<Error=Infallible> + Write> Update for ToDigest<T> {
+    fn update(&mut self, data: &[u8]) {
+        match self.inner.write_all(data) {
+            Ok(()) => {},
+            Err(_) => unreachable!(),
+        }
+    }
+}

--- a/embedded-io-adapters/src/lib.rs
+++ b/embedded-io-adapters/src/lib.rs
@@ -16,3 +16,6 @@ pub mod futures_03;
 #[cfg(feature = "tokio-1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio-1")))]
 pub mod tokio_1;
+
+#[cfg(feature = "digest")]
+pub mod digest;


### PR DESCRIPTION
there is an existing no_std trait `digest::Update` used in very popular crates like `sha2` - this trait is essentially equivalent to `ErrorType<Error=Infallible> + Write`

this PR adds adapters between the two traits.

example usage:
```
use embedded_io::Write;
use embedded_io_adapters::digest::FromDigest;
use sha2::{Digest, Sha256};

fn main() {
    let mut hasher = FromDigest::<Sha256>::default();
    hasher.write_all(b"hello world").unwrap();
    println!("{}", hex::encode_upper(hasher.into_inner().finalize()))
}
```