### PR TITLE
Release embedded-io 0.7

### DIFF
--- a/embedded-io-adapters/CHANGELOG.md
+++ b/embedded-io-adapters/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 - 2025-09-30
+
+- Update to embedded-io and embedded-io-async 0.7
+- Fix missing forwarding of provided method into std types
+
 ## 0.6.2 – 2025-08-06
 
 - Added `ToFmt` adapter for `core::fmt::Write`.

--- a/embedded-io-adapters/Cargo.toml
+++ b/embedded-io-adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-io-adapters"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.81"
 description = "Adapters between the `embedded-io` traits and other I/O traits"
@@ -18,8 +18,8 @@ tokio-1 = ["std", "dep:tokio", "dep:embedded-io-async", "embedded-io-async?/std"
 futures-03 = ["std", "dep:futures", "dep:embedded-io-async", "embedded-io-async?/std"]
 
 [dependencies]
-embedded-io = { version = "0.6", path = "../embedded-io" }
-embedded-io-async = { version = "0.6.1", path = "../embedded-io-async", optional = true }
+embedded-io = { version = "0.7", path = "../embedded-io" }
+embedded-io-async = { version = "0.7", path = "../embedded-io-async", optional = true }
 
 futures = { version = "0.3.21", features = ["std"], default-features = false, optional = true }
 tokio = { version = "1", features = ["io-util"], default-features = false, optional = true }

--- a/embedded-io-async/CHANGELOG.md
+++ b/embedded-io-async/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.7.0 - 2025-09-30
 
-Add unreleased changes here
+- Make `Write::flush()` a required method, aligning with std and embedded-io
+- Update to and align with embedded-io 0.7:
+  - Error type is updated to include core::Error
+  - Update `defmt` dependency to 1.0; rename feature from `defmt_03` to `defmt`
+  - Require `Read` and `Write` to be implemented for various Read and Write traits
+  - Fix missing method forwardings for blanket implementations
+  - Documentation updates
 
 ## 0.6.1 - 2023-11-28
 

--- a/embedded-io-async/Cargo.toml
+++ b/embedded-io-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-io-async"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.81"
 description = "Async embedded IO traits"
@@ -18,7 +18,7 @@ alloc = ["embedded-io/alloc"]
 defmt = ["dep:defmt", "embedded-io/defmt"]
 
 [dependencies]
-embedded-io = { version = "0.6.1", path = "../embedded-io" }
+embedded-io = { version = "0.7.0", path = "../embedded-io" }
 defmt = { package = "defmt", version = "1", optional = true }
 
 [package.metadata.docs.rs]

--- a/embedded-io/CHANGELOG.md
+++ b/embedded-io/CHANGELOG.md
@@ -5,12 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.7.0 - 2025-09-30
 
-- Added `core::error::Error` implementations for every custom `impl Error`
-- Migrated `std` feature-gated `std::error::Error` implementations to `core::error::Error`
-- Increased MSRV to 1.81 due to `core::error::Error`
-- Implemented `ReadReady` for `&[u8]` and `WriteReady` for `&mut [u8]`
+- Add trait dependency on `core::error::Error` to this crate's `Error` trait
+  - Implement the trait on all provided implementations
+  - Migrate `std` feature-gated `std::error::Error` implementations to `core::error::Error`
+- Updat `defmt` dependency to 1.0; rename feature from `defmt_03` to `defmt`
+- Increase MSRV to 1.81 due to `core::error::Error`
+- Implement `ReadReady` for `&[u8]` and `WriteReady` for `&mut [u8]`
+- Require `Read` and `Write` to be implemented for various Read and Write traits
+- Add provided `.seek_relative()` method to Seek
+- Fix missing method forwardings for blanket implementations
+- Specialize `.read_exact()` and `.write_all()` for slices
 
 ## 0.6.1 - 2023-10-22
 

--- a/embedded-io/Cargo.toml
+++ b/embedded-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-io"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.81"
 description = "Embedded IO traits"


### PR DESCRIPTION
Contributes-To: https://github.com/rust-embedded/embedded-hal/issues/566

This is a Draft PR until

* [x] I've satisfied all the interdependencies between other crates from the same workspace (as they have both version and path, they have to change their dependency version in the same PR),
* [x] I've updated the date to my best guess of the release, and
* [x] I think we won't wait more for any new changes (#566 has been open for a while, so that shouldn't be too long).