### PR TITLE
io: Remove redundant requirement on Debug

### DIFF
--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -172,7 +172,7 @@ impl From<std::io::ErrorKind> for ErrorKind {
 ///
 /// This trait allows generic code to do limited inspecting of errors,
 /// to react differently to different kinds.
-pub trait Error: fmt::Debug + core::error::Error {
+pub trait Error: core::error::Error {
     /// Get the kind of this error.
     fn kind(&self) -> ErrorKind;
 }


### PR DESCRIPTION
core::error::Error already depends on Debug, thus this is a compatible simplification.

This fixes a mistake I made in https://github.com/rust-embedded/embedded-hal/pull/672 found by @ROMemories in https://github.com/rust-embedded/embedded-hal/pull/672#pullrequestreview-3127089492 -- I guess this happened because never occurred to me that `core:…:Error: Debug`, because every time I had to implement Error, I only had to implement Display (because the type was typically Debug already).