### PR TITLE
io: make ReadReady, io_async::BufRead, and WriteReady super traits

### DIFF
--- a/embedded-io-async/src/lib.rs
+++ b/embedded-io-async/src/lib.rs
@@ -82,7 +82,7 @@ pub trait Read: ErrorType {
 /// Async buffered reader.
 ///
 /// This trait is the `embedded-io-async` equivalent of [`std::io::BufRead`].
-pub trait BufRead: ErrorType {
+pub trait BufRead: Read {
     /// Return the contents of the internal buffer, filling it with more data from the inner reader if it is empty.
     ///
     /// If no bytes are currently available to read, this function waits until at least one byte is available.

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -528,7 +528,7 @@ pub trait Seek: ErrorType {
 ///
 /// This allows using a [`Read`] or [`BufRead`] in a nonblocking fashion, i.e. trying to read
 /// only when it is ready.
-pub trait ReadReady: ErrorType {
+pub trait ReadReady: Read {
     /// Get whether the reader is ready for immediately reading.
     ///
     /// This usually means that there is either some bytes have been received and are buffered and ready to be read,
@@ -542,7 +542,7 @@ pub trait ReadReady: ErrorType {
 ///
 /// This allows using a [`Write`] in a nonblocking fashion, i.e. trying to write
 /// only when it is ready.
-pub trait WriteReady: ErrorType {
+pub trait WriteReady: Write {
     /// Get whether the writer is ready for immediately writing.
     ///
     /// This usually means that there is free space in the internal transmit buffer.


### PR DESCRIPTION
This is a follow-up of https://github.com/rust-embedded/embedded-hal/pull/690

This makes:

- `embedded_io_async::BufRead` a super trait of `embedded_io_async::Read`.
- `ReadReady` a super trait of `Read`.
- `WriteReady` a super trait of `Write`.