### PR TITLE
feat(async-io): make async `Write::flush` a required method

### DIFF
--- a/embedded-io-async/src/impls/slice_mut.rs
+++ b/embedded-io-async/src/impls/slice_mut.rs
@@ -26,6 +26,11 @@ impl Write for &mut [u8] {
     }
 
     #[inline]
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    #[inline]
     async fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
         if self.len() < buf.len() {
             return Err(SliceWriteError::Full);

--- a/embedded-io-async/src/impls/vec.rs
+++ b/embedded-io-async/src/impls/vec.rs
@@ -11,6 +11,11 @@ impl Write for Vec<u8> {
     }
 
     #[inline]
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    #[inline]
     async fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
         self.write(buf).await?;
         Ok(())

--- a/embedded-io-async/src/lib.rs
+++ b/embedded-io-async/src/lib.rs
@@ -127,9 +127,7 @@ pub trait Write: ErrorType {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error>;
 
     /// Flush this output stream, ensuring that all intermediately buffered contents reach their destination.
-    async fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    async fn flush(&mut self) -> Result<(), Self::Error>;
 
     /// Write an entire buffer into this writer.
     ///


### PR DESCRIPTION
This PR makes `embedded-io-async`'s `Write::flush` method a required method, meaning all implementors have to implement it.

This aligns this method with [`std`'s `Write::flush`](https://doc.rust-lang.org/nightly/std/io/trait.Write.html#tymethod.flush) and [`embedded-io`'s `Write::flush`](https://docs.rs/embedded-io/latest/embedded_io/trait.Write.html#tymethod.flush).

This PR is more a question than a proposal.
I could not find any documented reasons for the async `flush` being a provided method.
If this turns out to be intentional, I am happy to leave it as is and document the reason instead.

CC: @Dirbaio, who added this in the initial design ([`d6f6419`](https://github.com/rust-embedded/embedded-hal/commit/d6f641995fc1597920b7d86bf58d0332b7ebbaeb#diff-12ff19effb01592514fbd9b611c8e98309918524b9e794c1e3aea9c08b49e4a1R52-R54)).