### PR TITLE
Fix missing impls from and to std's io::ErrorKind for WriteZero variant

### DIFF
--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -137,6 +137,7 @@ impl From<ErrorKind> for std::io::ErrorKind {
             ErrorKind::Interrupted => std::io::ErrorKind::Interrupted,
             ErrorKind::Unsupported => std::io::ErrorKind::Unsupported,
             ErrorKind::OutOfMemory => std::io::ErrorKind::OutOfMemory,
+            ErrorKind::WriteZero => std::io::ErrorKind::WriteZero,
             _ => std::io::ErrorKind::Other,
         }
     }
@@ -163,6 +164,7 @@ impl From<std::io::ErrorKind> for ErrorKind {
             std::io::ErrorKind::Interrupted => ErrorKind::Interrupted,
             std::io::ErrorKind::Unsupported => ErrorKind::Unsupported,
             std::io::ErrorKind::OutOfMemory => ErrorKind::OutOfMemory,
+            std::io::ErrorKind::WriteZero => ErrorKind::WriteZero,
             _ => ErrorKind::Other,
         }
     }


### PR DESCRIPTION
There seems to be an ongoing PR (#679) for releasing the next embedded-io version. Since this PR adds missing impls for an already-existing ErrorKind variant, it should be merged ASAP