### PR TITLE
io: forward calls in blanket impls

### DIFF
--- a/embedded-io-async/src/lib.rs
+++ b/embedded-io-async/src/lib.rs
@@ -175,13 +175,20 @@ impl<T: ?Sized + Read> Read for &mut T {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         T::read(self, buf).await
     }
+
+    #[inline]
+    async fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), ReadExactError<Self::Error>> {
+        T::read_exact(self, buf).await
+    }
 }
 
 impl<T: ?Sized + BufRead> BufRead for &mut T {
+    #[inline]
     async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
         T::fill_buf(self).await
     }
 
+    #[inline]
     fn consume(&mut self, amt: usize) {
         T::consume(self, amt);
     }
@@ -197,11 +204,26 @@ impl<T: ?Sized + Write> Write for &mut T {
     async fn flush(&mut self) -> Result<(), Self::Error> {
         T::flush(self).await
     }
+
+    #[inline]
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        T::write_all(self, buf).await
+    }
 }
 
 impl<T: ?Sized + Seek> Seek for &mut T {
     #[inline]
     async fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
         T::seek(self, pos).await
+    }
+
+    #[inline]
+    async fn rewind(&mut self) -> Result<(), Self::Error> {
+        T::rewind(self).await
+    }
+
+    #[inline]
+    async fn stream_position(&mut self) -> Result<u64, Self::Error> {
+        T::stream_position(self).await
     }
 }

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -558,13 +558,20 @@ impl<T: ?Sized + Read> Read for &mut T {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         T::read(self, buf)
     }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), ReadExactError<Self::Error>> {
+        T::read_exact(self, buf)
+    }
 }
 
 impl<T: ?Sized + BufRead> BufRead for &mut T {
+    #[inline]
     fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
         T::fill_buf(self)
     }
 
+    #[inline]
     fn consume(&mut self, amt: usize) {
         T::consume(self, amt);
     }
@@ -580,12 +587,32 @@ impl<T: ?Sized + Write> Write for &mut T {
     fn flush(&mut self) -> Result<(), Self::Error> {
         T::flush(self)
     }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        T::write_all(self, buf)
+    }
 }
 
 impl<T: ?Sized + Seek> Seek for &mut T {
     #[inline]
     fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
         T::seek(self, pos)
+    }
+
+    #[inline]
+    fn rewind(&mut self) -> Result<(), Self::Error> {
+        T::rewind(self)
+    }
+
+    #[inline]
+    fn stream_position(&mut self) -> Result<u64, Self::Error> {
+        T::stream_position(self)
+    }
+
+    #[inline]
+    fn seek_relative(&mut self, offset: i64) -> Result<(), Self::Error> {
+        T::seek_relative(self, offset)
     }
 }
 


### PR DESCRIPTION
This PR fixes blanket implementations of the traits in `embedded-io` and `embedded-async-io`: some methods were not forwarded.