### PR TITLE
[io] Forward calls in Box adapters

### DIFF
--- a/embedded-io-async/src/impls/boxx.rs
+++ b/embedded-io-async/src/impls/boxx.rs
@@ -7,6 +7,14 @@ impl<T: ?Sized + Read> Read for Box<T> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         T::read(self, buf).await
     }
+
+    #[inline]
+    async fn read_exact(
+        &mut self,
+        buf: &mut [u8],
+    ) -> Result<(), crate::ReadExactError<Self::Error>> {
+        T::read_exact(self, buf).await
+    }
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
@@ -30,6 +38,11 @@ impl<T: ?Sized + Write> Write for Box<T> {
     }
 
     #[inline]
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        T::write_all(self, buf).await
+    }
+
+    #[inline]
     async fn flush(&mut self) -> Result<(), Self::Error> {
         T::flush(self).await
     }
@@ -40,5 +53,15 @@ impl<T: ?Sized + Seek> Seek for Box<T> {
     #[inline]
     async fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
         T::seek(self, pos).await
+    }
+
+    #[inline]
+    async fn rewind(&mut self) -> Result<(), Self::Error> {
+        T::rewind(self).await
+    }
+
+    #[inline]
+    async fn stream_position(&mut self) -> Result<u64, Self::Error> {
+        T::stream_position(self).await
     }
 }

--- a/embedded-io/src/impls/boxx.rs
+++ b/embedded-io/src/impls/boxx.rs
@@ -12,6 +12,11 @@ impl<T: ?Sized + Read> Read for Box<T> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         T::read(self, buf)
     }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), crate::ReadExactError<Self::Error>> {
+        T::read_exact(self, buf)
+    }
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
@@ -20,6 +25,7 @@ impl<T: ?Sized + BufRead> BufRead for Box<T> {
         T::fill_buf(self)
     }
 
+    #[inline]
     fn consume(&mut self, amt: usize) {
         T::consume(self, amt);
     }
@@ -33,6 +39,19 @@ impl<T: ?Sized + Write> Write for Box<T> {
     }
 
     #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        T::write_all(self, buf)
+    }
+
+    #[inline]
+    fn write_fmt(
+        &mut self,
+        fmt: core::fmt::Arguments<'_>,
+    ) -> Result<(), crate::WriteFmtError<Self::Error>> {
+        T::write_fmt(self, fmt)
+    }
+
+    #[inline]
     fn flush(&mut self) -> Result<(), Self::Error> {
         T::flush(self)
     }
@@ -43,6 +62,21 @@ impl<T: ?Sized + Seek> Seek for Box<T> {
     #[inline]
     fn seek(&mut self, pos: crate::SeekFrom) -> Result<u64, Self::Error> {
         T::seek(self, pos)
+    }
+
+    #[inline]
+    fn rewind(&mut self) -> Result<(), Self::Error> {
+        T::rewind(self)
+    }
+
+    #[inline]
+    fn stream_position(&mut self) -> Result<u64, Self::Error> {
+        T::stream_position(self)
+    }
+
+    #[inline]
+    fn seek_relative(&mut self, offset: i64) -> Result<(), Self::Error> {
+        T::seek_relative(self, offset)
     }
 }
 


### PR DESCRIPTION
This PR forwards calls in `Box<T>` impls of the Io traits. This avoids using default implementations when specialized impls are available.