### PR TITLE
io: remove supertraits for ReadReady, WriteReady. Release 0.7.1

### DIFF
--- a/embedded-io-async/CHANGELOG.md
+++ b/embedded-io-async/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Require `Read` and `Write` to be implemented for various Read and Write traits
   - Fix missing method forwardings for blanket implementations
   - Documentation updates
+- Implement `Read`, `ReadReady`, `BufRead`, `Write`, and `WriteReady` for `VecDeque<u8>`
 
 ## 0.6.1 - 2023-11-28
 

--- a/embedded-io/CHANGELOG.md
+++ b/embedded-io/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 - 2025-09-30
+
+- Do not require `Read` and `Write` to be implemented for `ReadReady` and `WriteReady`.
+
 ## 0.7.0 - 2025-09-30
 
 - Add trait dependency on `core::error::Error` to this crate's `Error` trait
@@ -17,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add provided `.seek_relative()` method to Seek
 - Fix missing method forwardings for blanket implementations
 - Specialize `.read_exact()` and `.write_all()` for slices
+- Implement `Read`, `ReadReady`, `BufRead`, `Write`, and `WriteReady` for `VecDeque<u8>`
 
 ## 0.6.1 - 2023-10-22
 

--- a/embedded-io/Cargo.toml
+++ b/embedded-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-io"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.81"
 description = "Embedded IO traits"

--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -530,7 +530,7 @@ pub trait Seek: ErrorType {
 ///
 /// This allows using a [`Read`] or [`BufRead`] in a nonblocking fashion, i.e. trying to read
 /// only when it is ready.
-pub trait ReadReady: Read {
+pub trait ReadReady: ErrorType {
     /// Get whether the reader is ready for immediately reading.
     ///
     /// This usually means that there is either some bytes have been received and are buffered and ready to be read,
@@ -544,7 +544,7 @@ pub trait ReadReady: Read {
 ///
 /// This allows using a [`Write`] in a nonblocking fashion, i.e. trying to write
 /// only when it is ready.
-pub trait WriteReady: Write {
+pub trait WriteReady: ErrorType {
     /// Get whether the writer is ready for immediately writing.
     ///
     /// This usually means that there is free space in the internal transmit buffer.


### PR DESCRIPTION
- **io: remove `Read`/`Write` supertrait for `ReadReady`/`WriteReady`.**

turns out we screwed up this in 0.7.0. I've yanked those for now.  `ReadReady`/`WriteReady` are shared between blocking and async (the embedded-io-async crate just reexports them) so they shouldn't have the blocking `Read`/`Write` as supertraits.

- **Release embedded-io 0.7.1**
