### PR TITLE
Fix items missing from the embedded-io{,-async} 0.7 changelog

### DIFF
--- a/embedded-io-async/CHANGELOG.md
+++ b/embedded-io-async/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make `Write::flush()` a required method, aligning with std and embedded-io
 - Update to and align with embedded-io 0.7:
+  - Increase MSRV to 1.81
   - Error type is updated to include core::Error
   - Update `defmt` dependency to 1.0; rename feature from `defmt_03` to `defmt`
   - Require `Read` and `Write` to be implemented for various Read and Write traits
   - Fix missing method forwardings for blanket implementations
+  - Implement `Read`, `ReadReady`, `BufRead`, `Write`, and `WriteReady` for `VecDeque<u8>`
   - Documentation updates
 
 ## 0.6.1 - 2023-11-28

--- a/embedded-io/CHANGELOG.md
+++ b/embedded-io/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add provided `.seek_relative()` method to Seek
 - Fix missing method forwardings for blanket implementations
 - Specialize `.read_exact()` and `.write_all()` for slices
+- Implement `Read`, `ReadReady`, `BufRead`, `Write`, and `WriteReady` for `VecDeque<u8>`
 
 ## 0.6.1 - 2023-10-22
 


### PR DESCRIPTION
Doing the last fixes to https://github.com/rust-embedded/embedded-hal/pull/679, I somehow managed to not commit the final touches to the changelog; claimed to have done them in https://github.com/rust-embedded/embedded-hal/pull/679#issuecomment-3353357561, but that was only the rebase onto the latest merges, not the fixups to the changelog themselves.

<del>Apparently, doing the release (tagging and uploading) is not automated, so merging this quickly would be great before enacting the release.

Pinging @Dirbaio who reviewed/merged #679; sorry for the noise.</del>

[edit: saw it's already published but yanked, so this will be a fix only for future releases' log correctness. Also, this is now the time when I integrate a `git status` into my shell prompt.]