### PR TITLE
Propagate lower-level errors as sources for embedded_io error types.

### DIFF
--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -261,7 +261,14 @@ impl<E: fmt::Debug> fmt::Display for ReadExactError<E> {
     }
 }
 
-impl<E: fmt::Debug> core::error::Error for ReadExactError<E> {}
+impl<E: core::error::Error + 'static> core::error::Error for ReadExactError<E> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::UnexpectedEof => None,
+            Self::Other(error) => Some(error),
+        }
+    }
+}
 
 /// Errors that could be returned by `Write` on `&mut [u8]`.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -294,7 +301,14 @@ impl<E: fmt::Debug> fmt::Display for WriteFmtError<E> {
     }
 }
 
-impl<E: fmt::Debug> core::error::Error for WriteFmtError<E> {}
+impl<E: core::error::Error + 'static> core::error::Error for WriteFmtError<E> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::FmtError => None,
+            Self::Other(error) => Some(error),
+        }
+    }
+}
 
 /// Blocking reader.
 ///


### PR DESCRIPTION
This expands the `core::error::Error` implementations for both `embedded_io::ReadExactError` and `embedded_io::WriteFmtError` to implement the `source()` function to return the underlying error contained in the `Other` variant.

Note that this changes the bounds for the `core::error::Error` implementations to both types to require `E: core::error::Error + 'static`, but in practice this shouldn't cause many issues since using both `Read::read_exact()` and `Write::write_fmt()` relies on the `ErrorType` trait, which requires its `Error` to implement `core::error::Error`. Technically this is a breaking change, and would possibly break places where someone is constructing these error types outside of the context of the io traits.