### PR TITLE
Implement Into<Infallible> when spi::DeviceError is infallible

### DIFF
--- a/embedded-hal-bus/src/spi/mod.rs
+++ b/embedded-hal-bus/src/spi/mod.rs
@@ -1,5 +1,6 @@
 //! `SpiDevice` implementations.
 
+use core::convert::Infallible;
 use core::fmt::{self, Debug, Display, Formatter};
 use embedded_hal::spi::{Error, ErrorKind};
 
@@ -59,6 +60,15 @@ where
         match self {
             Self::Spi(e) => e.kind(),
             Self::Cs(_) => ErrorKind::ChipSelectFault,
+        }
+    }
+}
+
+impl From<DeviceError<Infallible, Infallible>> for Infallible {
+    fn from(value: DeviceError<Infallible, Infallible>) -> Self {
+        match value {
+            DeviceError::Spi(e) => e,
+            DeviceError::Cs(e) => e,
         }
     }
 }


### PR DESCRIPTION
I'm currently writing a SPI device driver which can use any struct that implements `embedded_hal::spi::SpiDevice` internally, such as a `embedded_hal_bus::spi::ExclusiveDevice`. I would like to provide an infallible API for platforms which have infallible SPI transactions, such as the RP2350. A SPI transaction on these platforms returns `Result<(), DeviceError<Infallible, Infallible>>` if we use an `ExclusiveDevice`, which can obviously be safely unwrapped.

To write this API I create a simple wrapper struct around the original fallible API. I tried to constrain the error type by `Into<Infallible>` such that any error type that is convertible to `Infallible` can be used. However, `DeviceError<Infallible, Infallible>` does not implement this trait yet. So I implemented it in this PR.

Happy to hear opinions and possible alternatives, this was the first solution I saw.