### PR TITLE
Add `defmt` feature to embedded-can Cargo.toml

### DIFF
--- a/embedded-can/Cargo.toml
+++ b/embedded-can/Cargo.toml
@@ -15,3 +15,6 @@ repository = "https://github.com/rust-embedded/embedded-hal"
 [dependencies]
 nb = "1"
 defmt = { version = "1", optional = true }
+
+[features]
+defmt = ["dep:defmt"]


### PR DESCRIPTION
In order for the `defmt` dep to be used, it needs to be enabled by a feature (in this case, of the same name). As far as I can tell, simply having the dependency be optional does not create an implicit feature to enable it. 