### PR TITLE
Update embedded-hal-async changelog

### DIFF
--- a/embedded-hal-async/CHANGELOG.md
+++ b/embedded-hal-async/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-No unreleased changes yet.
+### Added
+- Add `async` versions of `OutputPin`, `StatefulOutputPin` and `InputPin`.
+- Re-export `digital` error types from `embedded-hal`.
 
 ## [v1.0.0] - 2023-12-28
 


### PR DESCRIPTION
PR #727 brought to my attention that the `embedded-hal-async` changelog was missing some entries.