### PR TITLE
[io] Require static lifetime bound on Error

### DIFF
--- a/embedded-io/src/lib.rs
+++ b/embedded-io/src/lib.rs
@@ -174,7 +174,7 @@ impl From<std::io::ErrorKind> for ErrorKind {
 ///
 /// This trait allows generic code to do limited inspecting of errors,
 /// to react differently to different kinds.
-pub trait Error: core::error::Error {
+pub trait Error: core::error::Error + 'static {
     /// Get the kind of this error.
     fn kind(&self) -> ErrorKind;
 }


### PR DESCRIPTION
This PR requires types that implement `embedded_io::Error` to have a static lifetime.
This is a breaking change. However, this should not widely impact the ecosystem because most of the error types are static anyway.

Why this change?
This is basically the same rationales as https://github.com/rust-embedded/embedded-hal/commit/d02f6db11021c8889bb22cd8ec60f0dc47eabb38
Many crates require error types to implement `core::error::Error` and to be `'static`.
One of the reason is because of [`core::error::Error::source`](https://doc.rust-lang.org/beta/core/error/trait.Error.html#method.source) that returns a `dyn core::error::Error +'static`.

Working with these crates and `embedded-io` makes things hard because you have to constraint the `Error` associated type on every generic functions.
Here is an example:

```rs
fn f<R: embedded_io::Read>(r: &mut R) -> Result<(), a_crate::Error<R::Error>>
where R::Error: 'static {}
```

Requiring `'static` on `embedded_io::Error` makes things less tedious.
Moreover, it is considered as a best practice in the Rust community of requiring both `core::error::Error` and `'static` on Error types.

I didn't make the change on other crates because their Error types don't implement core::error::Error (yet?).