### PR TITLE
embedded-io-async: clarify cancel safety semantics for Read and Write

### DIFF
--- a/embedded-io-async/src/lib.rs
+++ b/embedded-io-async/src/lib.rs
@@ -46,14 +46,24 @@ pub trait Read: ErrorType {
     /// If `buf.len() == 0`, `read` returns without waiting, with either `Ok(0)` or an error.
     /// The `Ok(0)` doesn't indicate EOF, unlike when called with a non-empty buffer.
     ///
-    /// Implementations are encouraged to make this function side-effect-free on cancel (AKA "cancel-safe"), i.e.
-    /// guarantee that if you cancel (drop) a `read()` future that hasn't completed yet, the stream's
-    /// state hasn't changed (no bytes have been read).
+    /// # Cancel Safety
     ///
-    /// This is not a requirement to allow implementations that read into the user's buffer straight from
-    /// the hardware with e.g. DMA.
+    /// **This method is NOT guaranteed to be cancel-safe.**
     ///
-    /// Implementations should document whether they're actually side-effect-free on cancel or not.
+    /// If a `read()` future is dropped before it completes, bytes that have already been transferred
+    /// from the hardware FIFO or DMA buffer may be silently discarded — no error is returned, and
+    /// no indication is given to the caller that data was lost. The next call to `read()` will return
+    /// bytes received *after* the cancellation point, not the discarded bytes.
+    ///
+    /// Implementations that are able to guarantee cancel safety (i.e. that dropping a pending future
+    /// leaves the stream state unchanged — no bytes consumed) SHOULD document this explicitly and
+    /// MAY implement the `CancelSafeRead` marker trait when it becomes available.
+    ///
+    /// Implementations that cannot guarantee cancel safety (e.g. those that use DMA to write
+    /// directly into the caller's buffer) MUST document this limitation.
+    ///
+    /// Callers that require cancel-safe reads SHOULD use a pattern that ensures the future runs to
+    /// completion (e.g. a dedicated read task) rather than relying on cancel safety.
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error>;
 
     /// Read the exact number of bytes required to fill `buf`.
@@ -116,14 +126,19 @@ pub trait Write: ErrorType {
     /// If `buf.len() == 0`, `write` returns without waiting, with either `Ok(0)` or an error.
     /// The `Ok(0)` doesn't indicate an error.
     ///
-    /// Implementations are encouraged to make this function side-effect-free on cancel (AKA "cancel-safe"), i.e.
-    /// guarantee that if you cancel (drop) a `write()` future that hasn't completed yet, the stream's
-    /// state hasn't changed (no bytes have been written).
+    /// # Cancel Safety
     ///
-    /// This is not a requirement to allow implementations that write from the user's buffer straight to
-    /// the hardware with e.g. DMA.
+    /// **This method is NOT guaranteed to be cancel-safe.**
     ///
-    /// Implementations should document whether they're actually side-effect-free on cancel or not.
+    /// If a `write()` future is dropped before it completes, bytes may have already been submitted
+    /// to the hardware without the caller's knowledge — no error is returned. The number of bytes
+    /// actually written is unknown.
+    ///
+    /// Implementations that are able to guarantee cancel safety (i.e. that dropping a pending future
+    /// leaves the stream state unchanged — no bytes written) SHOULD document this explicitly.
+    ///
+    /// Implementations that cannot guarantee cancel safety (e.g. those that use DMA directly from
+    /// the caller's buffer) MUST document this limitation.
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error>;
 
     /// Flush this output stream, ensuring that all intermediately buffered contents reach their destination.


### PR DESCRIPTION
Fixes #719

## Problem

The documentation for `Read::read` and `Write::write` in `embedded-io-async` used permissive language — "implementations are *encouraged*" and "implementations *should* document" — that left both callers and implementors without a clear contract. Issue #719 identifies the concrete failure mode this ambiguity enables:

When a `read()` future is dropped mid-transfer, bytes already received from the hardware FIFO or DMA buffer are silently discarded. No error is returned. The caller has no way to detect or recover from the data loss. In safety-critical embedded contexts (CAN/UART frames, ISO 26262), this is a **silent data loss** that can propagate through state machines without triggering any diagnostic path.

## Fix

Rewrite the cancel-safety sections using normative `SHOULD`/`MUST` language and a dedicated `# Cancel Safety` heading (consistent with Tokio's convention):

- States explicitly: **this method is NOT guaranteed to be cancel-safe by default**
- Names the concrete failure mode: bytes in hardware FIFO/DMA may be silently dropped
- Requires implementations that cannot guarantee cancel safety to **MUST document** this
- Gives callers actionable guidance: run the future to completion rather than relying on cancel safety
- References the future `CancelSafeRead` marker trait path for opt-in

The PR changes documentation only. No trait methods are added, no signatures change, no semver bump required. The architectural path to a `CancelSafeRead` marker trait (issue #719's long-term ask) is left for a follow-up RFC.

## Existing Behavior Audit (OPS-RULE-016)

| File | Line | Current state |
|------|------|--------------|
| `embedded-io-async/src/lib.rs` | 49–56 | `Read::read` cancel-safety: "encouraged", "should document" — no normative contract |
| `embedded-io-async/src/lib.rs` | 119–126 | `Write::write` cancel-safety: identical permissive framing |
| PR #469 ("io: expand docs", 2023-07-12) | — | Prior documentation pass; introduced "encouraged" language that this PR strengthens |

## Scope Classification (OPS-RULE-017)

**Category (b): Minor enhancement (documentation).** No trait method signatures changed. No API-breaking change. A normative documentation tightening for existing behavior that was already the intended semantic, per the issue discussion. A full API change (new `CancelSafeRead` trait) would be category (c) requiring RFC — that is out of scope here.

## Test

`cargo check -p embedded-io-async` passes. Documentation-only changes require no additional test code; the trait method signatures are unchanged.

## Prior Art (OPS-RULE-018)

1. **PR #469** — *"io: expand docs"* (merged 2023-07-12) — the prior documentation pass that added "encouraged" language; this PR closes the gap that #469 opened by making the non-guarantee explicit
2. **Issue #37** — *"Explore DMA-based APIs built on top of `&'static mut` references"* (open, 2018) — root structural reason cancel safety is non-trivial for hardware FIFO implementations; the DMA buffer ownership problem this fix warns about
3. **PR #627** — *"Add BufReader impl"* (open) — concrete mechanism by which cancel safety can be achieved at the adapter layer without trait changes; this PR's documentation explicitly allows for that approach

*AI-assisted — authored with Claude, reviewed by Komada.*